### PR TITLE
refactor: Rename package to `vole-app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
-# Vol-E (Volume Explorer)
+# Vol-E App
+
+Volume Explorer (Vol-E) is a browser based volume viewer built with React and WebGL (Three.js). This package wraps the [vole-core](https://github.com/allen-cell-animated/volume-viewer) library.
 
 For the latest stable release, please visit https://allen-cell-animated.github.io/website-3d-cell-viewer-release/
 
-This is a browser based volume viewer built with React and WebGL (Three.js).
 Volume data is provided to the core 3d viewer via one of the following file formats:
-* a url to a OME-ZARR image
-* a url to a OME-TIFF file
-* a json file containing dimensions and other metadata, and texture atlases (png files containing volume slices tiled across the 2d image). These texture atlases must be prepared in advance before loading into this viewer.
 
+- a url to a OME-ZARR image
+- a url to a OME-TIFF file
+- a json file containing dimensions and other metadata, and texture atlases (png files containing volume slices tiled across the 2d image). These texture atlases must be prepared in advance before loading into this viewer.
 
 The volume shader itself is a heavily modified version of one that has distant origins in [Bisque](http://bioimage.ucsb.edu/bisque).
 
 ## to use
+
 - `https://allen-cell-animated.github.io/website-3d-cell-viewer-release/?url=path/to/ZARR`
-- for more url parameters, see `public/index.tsx`
+- for more url parameters, see [`website\utils\url_utils.ts#L82`](website\utils\url_utils.ts#L82)
 
 or as React component:
 
-- `npm install @aics/web-3d-viewer`
-- import the app as `import { ImageViewerApp } from "@aics/web-3d-viewer"`
-- send in props as is shown in public/index.jsx
+- `npm install @aics/vole-app`
+- import the app as `import { ImageViewerApp } from "@aics/vole-app"`
+- send in props as is shown in [`public/index.jsx`](public/index.tsx)
+
 ```
     <ImageViewerApp
         baseUrl="http://dev-aics-dtp-001.corp.alleninstitute.org/cellviewer-1-4-0/Cell-Viewer_Thumbnails/"
@@ -33,10 +36,10 @@ or as React component:
 Clone the repository and run the following commands in the root of the project:
 
 ```cmd
-docker build -t 3d-volume-viewer-image .
-docker run --rm -p 9020:80 --name 3d-volume-viewer 3d-volume-viewer-image
+docker build -t vole-app-image .
+docker run --rm -p 9020:80 --name vole-app vole-app-image
 ```
 
-This will create a new docker image called `3d-volume-viewer` and run it on port 9020. You can access the viewer by navigating to http://localhost:9020 in your browser.
+This will create a new docker image called `vole-app` and run it on port 9020. You can access the viewer by navigating to http://localhost:9020 in your browser.
 
 To rebuild changes, run the above commands again. (The `--rm` flag will automatically delete the existing container when it is stopped.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@aics/web-3d-viewer",
+  "name": "@aics/vole-app",
   "version": "2.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@aics/web-3d-viewer",
+      "name": "@aics/vole-app",
       "version": "2.10.4",
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.10.4",
       "license": "ISC",
       "dependencies": {
-        "@aics/volume-viewer": "^3.12.3",
+        "@aics/vole-core": "^3.12.4",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -96,10 +96,10 @@
         "three": "^0.144.0"
       }
     },
-    "node_modules/@aics/volume-viewer": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.12.3.tgz",
-      "integrity": "sha512-iH4BgfucChsaQO6/WEf3rBMnyCETXONhBmhkHKKX3YrJ8hzswEw1NlgBUFKCj5xUxB1K943xVCRgQolYoBbfGA==",
+    "node_modules/@aics/vole-core": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.12.4.tgz",
+      "integrity": "sha512-9cgk08J8muHcm1kfFo7ZYr4Glg7R3/YByrs9iRP3uaTzGzlti57IGcQoT5W12dEAKH0fBUQdcm6wjvypEviCpQ==",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",
@@ -110,7 +110,7 @@
         "zarrita": "^0.3.2"
       }
     },
-    "node_modules/@aics/volume-viewer/node_modules/three": {
+    "node_modules/@aics/vole-core/node_modules/three": {
       "version": "0.171.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
       "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ=="

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^3.12.3",
+    "@aics/vole-core": "^3.12.4",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aics/web-3d-viewer",
+  "name": "@aics/vole-app",
   "version": "2.10.4",
   "description": "web view of cell volume images",
   "repository": "github:allen-cell-animated/website-3d-cell-viewer",

--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -1,4 +1,4 @@
-import { Lut, View3d, Volume } from "@aics/volume-viewer";
+import { Lut, View3d, Volume } from "@aics/vole-core";
 import React, { useEffect } from "react";
 
 import { controlPointsToLut, rampToControlPoints } from "../../shared/utils/controlPointsToLut";

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -10,7 +10,7 @@ import {
   Volume,
   VolumeFileFormat,
   VolumeLoaderContext,
-} from "@aics/volume-viewer";
+} from "@aics/vole-core";
 import { Layout } from "antd";
 import { debounce } from "lodash";
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -1,4 +1,4 @@
-import type { RawArrayData, RawArrayInfo, View3d, Volume } from "@aics/volume-viewer";
+import type { RawArrayData, RawArrayInfo, View3d, Volume } from "@aics/vole-core";
 import { MutableRefObject } from "react";
 
 import type { MetadataRecord } from "../../shared/types";

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -1,4 +1,4 @@
-import { Volume } from "@aics/volume-viewer";
+import { Volume } from "@aics/vole-core";
 import { CaretRightOutlined, PauseOutlined } from "@ant-design/icons";
 import { Button, Tooltip } from "antd";
 import React, { useCallback, useEffect, useState } from "react";

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -1,15 +1,15 @@
-import React from "react";
-import { View3d, Volume } from "@aics/volume-viewer";
+import { View3d, Volume } from "@aics/vole-core";
 import { LoadingOutlined } from "@ant-design/icons";
+import React from "react";
 
-import { AxisName, PerAxis, Styles } from "../../shared/types";
 import { ViewMode } from "../../shared/enums";
-import { ViewerSettingUpdater } from "../ViewerStateProvider/types";
+import { AxisName, PerAxis, Styles } from "../../shared/types";
 import PlayControls from "../../shared/utils/playControls";
+import { ViewerSettingUpdater } from "../ViewerStateProvider/types";
 
-import { connectToViewerState } from "../ViewerStateProvider";
 import AxisClipSliders from "../AxisClipSliders";
 import BottomPanel from "../BottomPanel";
+import { connectToViewerState } from "../ViewerStateProvider";
 
 import "./styles.css";
 

--- a/src/aics-image-viewer/components/ChannelsWidget.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget.tsx
@@ -1,4 +1,4 @@
-import { Channel } from "@aics/volume-viewer";
+import { Channel } from "@aics/vole-core";
 import { Collapse, CollapseProps, List } from "antd";
 import React from "react";
 

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -1,20 +1,21 @@
-import React, { useState, useCallback } from "react";
-import { Button, List, Checkbox } from "antd";
+import { Channel } from "@aics/vole-core";
+import { Button, Checkbox, List } from "antd";
 import { CheckboxChangeEvent } from "antd/lib/checkbox";
-import { Channel } from "@aics/volume-viewer";
+import React, { useCallback, useState } from "react";
 
-import TfEditor from "../TfEditor";
 import { ISOSURFACE_OPACITY_SLIDER_MAX } from "../../shared/constants";
-import ColorPicker from "../ColorPicker";
-import { ColorObject, colorObjectToArray, colorArrayToObject } from "../../shared/utils/colorRepresentations";
+import { IsosurfaceFormat } from "../../shared/types";
+import { colorArrayToObject, ColorObject, colorObjectToArray } from "../../shared/utils/colorRepresentations";
 import {
-  type ChannelState,
   type ChannelSettingUpdater,
+  type ChannelState,
   type SingleChannelSettingUpdater,
 } from "../ViewerStateProvider/types";
-import { IsosurfaceFormat } from "../../shared/types";
-import ViewerIcon from "../shared/ViewerIcon";
+
+import ColorPicker from "../ColorPicker";
 import SliderRow from "../shared/SliderRow";
+import ViewerIcon from "../shared/ViewerIcon";
+import TfEditor from "../TfEditor";
 
 import "./styles.css";
 
@@ -40,20 +41,20 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
   );
 
   const volumeCheckHandler = ({ target }: CheckboxChangeEvent): void => {
-    changeChannelSetting(index, {"volumeEnabled": target.checked});
+    changeChannelSetting(index, { volumeEnabled: target.checked });
   };
 
   const isosurfaceCheckHandler = ({ target }: CheckboxChangeEvent): void => {
-    changeChannelSetting(index, {"isosurfaceEnabled": target.checked});
+    changeChannelSetting(index, { isosurfaceEnabled: target.checked });
   };
 
-  const onIsovalueChange = ([newValue]: number[]): void => changeSettingForThisChannel({"isovalue": newValue});
+  const onIsovalueChange = ([newValue]: number[]): void => changeSettingForThisChannel({ isovalue: newValue });
   const onOpacityChange = ([newValue]: number[]): void =>
-    changeSettingForThisChannel({"opacity": newValue / ISOSURFACE_OPACITY_SLIDER_MAX});
+    changeSettingForThisChannel({ opacity: newValue / ISOSURFACE_OPACITY_SLIDER_MAX });
 
   const onColorChange = (newRGB: ColorObject, _oldRGB?: ColorObject, index?: number): void => {
     const color = colorObjectToArray(newRGB);
-    props.changeChannelSetting(index!, {"color": color});
+    props.changeChannelSetting(index!, { color: color });
   };
 
   const createColorPicker = (): React.ReactNode => (

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -1,4 +1,4 @@
-import { VolumeLoadError, VolumeLoadErrorType } from "@aics/volume-viewer";
+import { VolumeLoadError, VolumeLoadErrorType } from "@aics/vole-core";
 import { RightOutlined } from "@ant-design/icons";
 import { Alert, Button } from "antd";
 import React from "react";

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -1,4 +1,4 @@
-import { Channel, ControlPoint, Histogram, Lut } from "@aics/volume-viewer";
+import { Channel, ControlPoint, Histogram, Lut } from "@aics/vole-core";
 import { Button, Checkbox, InputNumber, Tooltip } from "antd";
 import * as d3 from "d3";
 import "nouislider/distribute/nouislider.css";

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -1,4 +1,4 @@
-import { CameraState, ControlPoint } from "@aics/volume-viewer";
+import { CameraState, ControlPoint } from "@aics/vole-core";
 
 import type { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import type { PerAxis } from "../../shared/types";

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -1,4 +1,4 @@
-import { CameraState } from "@aics/volume-viewer";
+import { CameraState } from "@aics/vole-core";
 
 import { ChannelState, ViewerState } from "../components/ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "./enums";

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -1,6 +1,7 @@
-import { Channel, ControlPoint, Histogram, Lut, Volume, remapControlPoints } from "@aics/volume-viewer";
-import { findFirstChannelMatch, ViewerChannelSetting, ViewerChannelSettings } from "./viewerChannelSettings";
+import { Channel, ControlPoint, Histogram, Lut, remapControlPoints, Volume } from "@aics/vole-core";
+
 import { LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE, TFEDITOR_DEFAULT_COLOR, TFEDITOR_MAX_BIN } from "../constants";
+import { findFirstChannelMatch, ViewerChannelSetting, ViewerChannelSettings } from "./viewerChannelSettings";
 
 // @param {Object[]} controlPoints - array of {x:number, opacity:number, color:string}
 // @return {Uint8Array} array of length 256*4 representing the rgba values of the gradient

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -1,4 +1,4 @@
-import { ControlPoint } from "@aics/volume-viewer";
+import { ControlPoint } from "@aics/vole-core";
 
 import { OTHER_CHANNEL_KEY, SINGLE_GROUP_CHANNEL_KEY } from "../constants";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,6 @@ export type {
 export { ViewMode, RenderMode, ImageType } from "./aics-image-viewer/shared/enums";
 
 export type { AppProps } from "./aics-image-viewer/components/App/types";
-export type { RawArrayData, RawArrayInfo } from "@aics/volume-viewer";
+export type { RawArrayData, RawArrayInfo } from "@aics/vole-core";
 
 export { ImageViewerApp, ViewerStateProvider };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,7 +8,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 module.exports = (env) => {
   return {
-    entry: {index: "./public/index.tsx", reroute: "./public/gh-reroute/index.tsx"},
+    entry: { index: "./public/index.tsx", reroute: "./public/gh-reroute/index.tsx" },
     output: {
       path: path.resolve(__dirname, "imageviewer"),
       filename: "[name].bundle.js",
@@ -35,7 +35,7 @@ module.exports = (env) => {
       new MiniCssExtractPlugin(),
       new webpack.DefinePlugin({
         WEBSITE3DCELLVIEWER_VERSION: JSON.stringify(require("./package.json").version),
-        VOLUMEVIEWER_VERSION: JSON.stringify(require("./node_modules/@aics/volume-viewer/package.json").version),
+        VOLUMEVIEWER_VERSION: JSON.stringify(require("./node_modules/@aics/vole-core/package.json").version),
         WEBSITE3DCELLVIEWER_BUILD_ENVIRONMENT: JSON.stringify(env.env),
         WEBSITE3DCELLVIEWER_BASENAME: JSON.stringify(env.basename),
       }),

--- a/website/components/AppWrapper.tsx
+++ b/website/components/AppWrapper.tsx
@@ -1,18 +1,18 @@
-import { View3d } from "@aics/volume-viewer";
+import { View3d } from "@aics/vole-core";
 import React, { ReactElement, useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import { ImageViewerApp, ViewerStateProvider } from "../../src";
 import { ViewerState } from "../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { getDefaultViewerChannelSettings } from "../../src/aics-image-viewer/shared/constants";
+import { AppDataProps } from "../types";
+import { parseViewerUrlParams } from "../utils/url_utils";
+import { FlexRowAlignCenter } from "./LandingPage/utils";
 
 import Header, { HEADER_HEIGHT_PX } from "./Header";
 import HelpDropdown from "./HelpDropdown";
-import { FlexRowAlignCenter } from "./LandingPage/utils";
 import LoadModal from "./Modals/LoadModal";
 import ShareModal from "./Modals/ShareModal";
-import { AppDataProps } from "../types";
-import { parseViewerUrlParams } from "../utils/url_utils";
 
 const DEFAULT_APP_PROPS: AppDataProps = {
   imageUrl: "",

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -1,17 +1,18 @@
-import { Button, Input, Modal, notification } from "antd";
+import { View3d } from "@aics/vole-core";
 import { ShareAltOutlined } from "@ant-design/icons";
-import React, { useState, useRef } from "react";
+import { Button, Input, Modal, notification } from "antd";
+import React, { useRef, useState } from "react";
 import styled from "styled-components";
-import { View3d } from "@aics/volume-viewer";
 
-import { FlexRow } from "../LandingPage/utils";
+import { ViewerStateContextType } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { AppDataProps } from "../../types";
+import { ENCODED_COLON_REGEX, ENCODED_COMMA_REGEX, serializeViewerUrlParams } from "../../utils/url_utils";
+import { FlexRow } from "../LandingPage/utils";
+
 import {
   ALL_VIEWER_STATE_KEYS,
   connectToViewerState,
 } from "../../../src/aics-image-viewer/components/ViewerStateProvider";
-import { ViewerStateContextType } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
-import { ENCODED_COLON_REGEX, ENCODED_COMMA_REGEX, serializeViewerUrlParams } from "../../utils/url_utils";
 
 type ShareModalProps = {
   appProps: AppDataProps;

--- a/website/utils/test/datatype_utils.test.ts
+++ b/website/utils/test/datatype_utils.test.ts
@@ -1,5 +1,5 @@
+import { ControlPoint } from "@aics/vole-core";
 import { describe, expect, it } from "@jest/globals";
-import { ControlPoint } from "@aics/volume-viewer";
 import { isEqual } from "lodash";
 
 describe("isEqual", () => {

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -1,4 +1,4 @@
-import { CameraState } from "@aics/volume-viewer";
+import { CameraState } from "@aics/vole-core";
 import { describe, expect, it } from "@jest/globals";
 
 import { ChannelState, ViewerState } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -1,27 +1,27 @@
-import FirebaseRequest, { DatasetMetaData } from "../../public/firebase";
-import { CameraState, ControlPoint } from "@aics/volume-viewer";
+import { CameraState, ControlPoint } from "@aics/vole-core";
+import { isEqual } from "lodash";
 
+import FirebaseRequest, { DatasetMetaData } from "../../public/firebase";
+import type { AppProps } from "../../src/aics-image-viewer/components/App/types";
 import type {
   ChannelState,
   ViewerState,
   ViewerStateContextType,
 } from "../../src/aics-image-viewer/components/ViewerStateProvider/types";
-import type { AppProps } from "../../src/aics-image-viewer/components/App/types";
-import { ImageType, RenderMode, ViewMode } from "../../src/aics-image-viewer/shared/enums";
-import {
-  ViewerChannelSetting,
-  ViewerChannelSettings,
-} from "../../src/aics-image-viewer/shared/utils/viewerChannelSettings";
-import { ColorArray } from "../../src/aics-image-viewer/shared/utils/colorRepresentations";
-import { PerAxis } from "../../src/aics-image-viewer/shared/types";
-import { clamp } from "./math_utils";
-import { removeMatchingProperties, removeUndefinedProperties } from "./datatype_utils";
-import { isEqual } from "lodash";
 import {
   getDefaultCameraState,
   getDefaultChannelState,
   getDefaultViewerState,
 } from "../../src/aics-image-viewer/shared/constants";
+import { ImageType, RenderMode, ViewMode } from "../../src/aics-image-viewer/shared/enums";
+import { PerAxis } from "../../src/aics-image-viewer/shared/types";
+import { ColorArray } from "../../src/aics-image-viewer/shared/utils/colorRepresentations";
+import {
+  ViewerChannelSetting,
+  ViewerChannelSettings,
+} from "../../src/aics-image-viewer/shared/utils/viewerChannelSettings";
+import { removeMatchingProperties, removeUndefinedProperties } from "./datatype_utils";
+import { clamp } from "./math_utils";
 
 export const ENCODED_COMMA_REGEX = /%2C/g;
 export const ENCODED_COLON_REGEX = /%3A/g;


### PR DESCRIPTION
Problem
=======
Part 1 of 2 for #355, "Rename package + import new VV package." This change performs the rename of the `web-3d-viewer` package to `vole-app` and updates imports to bring in the rename of the `volume-viewer` to `vole-core`.

Part 2 will require a rename of both this and the `volume-viewer` repositories! I'll be updating the GH pages actions and documentation links.

*Estimated review size: small, 10-15 minutes* (some imports got re-sorted so this may appear a bit larger)

Solution
========
- Renamed package in `package.json` and `package-lock.json`.
- Replaced `@aics/volume-viewer` with `@aics/vole-core`.
- Updated README.md
- Updated imports (+ import sorting) in files

## Type of change
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
