### PR TITLE
fix: Bumped actions/cache to `v4.2.2`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,8 +19,8 @@ jobs:
           node-version: ${{env.NODE_VERSION}}
 
       - name: Cache dependencies
-
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        # actions/cache@v4.2.2
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Problem
=======
Fixes #364, "GitHub Pages Nightly build is failing".

Bumps actions/cache to `v4.2.2` from a deprecated version.

*Estimated review size: tiny, <2 minutes*
