### PR TITLE
Usability: open control panel on tab change; make tf editor sliders more draggable

### DIFF
--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -1,19 +1,18 @@
+import { Button, Collapse, CollapseProps, Dropdown, Flex, MenuProps, Tooltip } from "antd";
+import { MenuInfo } from "rc-menu/lib/interface";
 import React from "react";
 
-import { Button, Dropdown, Tooltip, MenuProps, Collapse, CollapseProps, Flex } from "antd";
-import { MenuInfo } from "rc-menu/lib/interface";
+import { PRESET_COLOR_MAP } from "../../shared/constants";
+import { MetadataRecord } from "../../shared/types";
 
 import ChannelsWidget from "../ChannelsWidget";
-import GlobalVolumeControls, { GlobalVolumeControlsProps } from "../GlobalVolumeControls";
 import CustomizeWidget, { CustomizeWidgetProps } from "../CustomizeWidget";
+import GlobalVolumeControls, { GlobalVolumeControlsProps } from "../GlobalVolumeControls";
 import MetadataViewer from "../MetadataViewer";
-
-import { PRESET_COLOR_MAP } from "../../shared/constants";
+import ViewerIcon from "../shared/ViewerIcon";
+import { connectToViewerState } from "../ViewerStateProvider";
 
 import "./styles.css";
-import ViewerIcon from "../shared/ViewerIcon";
-import { MetadataRecord } from "../../shared/types";
-import { connectToViewerState } from "../ViewerStateProvider";
 
 type PropsOf<T> = T extends React.ComponentType<infer P> ? P : never;
 
@@ -46,7 +45,11 @@ const ControlTabNames = {
 };
 
 function ControlPanel(props: ControlPanelProps): React.ReactElement {
-  const [tab, setTab] = React.useState(ControlTab.Channels);
+  const [tab, _setTab] = React.useState(ControlTab.Channels);
+  const setTab = (newTab: ControlTab): void => {
+    _setTab(newTab);
+    props.setCollapsed(false);
+  };
 
   const controlPanelContainerRef = React.useRef<HTMLDivElement>(null);
   const getDropdownContainer = controlPanelContainerRef.current ? () => controlPanelContainerRef.current! : undefined;

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -479,6 +479,12 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
             <g className="ramp-sliders">
               <g transform={`translate(${xScale(props.ramp[0])})`}>
                 <line y1={innerHeight} strokeDasharray="5,5" strokeWidth={2} />
+                <line
+                  className="ramp-slider-click-target"
+                  y1={innerHeight}
+                  strokeWidth={5}
+                  onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Min)}
+                />
                 <path
                   d={sliderHandlePath}
                   transform={`translate(0,${innerHeight}) rotate(180)`}
@@ -487,6 +493,12 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
               </g>
               <g transform={`translate(${xScale(props.ramp[1])})`}>
                 <line y1={innerHeight} strokeDasharray="5,5" strokeWidth={2} />
+                <line
+                  className="ramp-slider-click-target"
+                  y1={innerHeight}
+                  strokeWidth={5}
+                  onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Max)}
+                />
                 <path d={sliderHandlePath} onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Max)} />
               </g>
             </g>

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -482,7 +482,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
                 <line
                   className="ramp-slider-click-target"
                   y1={innerHeight}
-                  strokeWidth={5}
+                  strokeWidth={6}
                   onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Min)}
                 />
                 <path
@@ -496,7 +496,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
                 <line
                   className="ramp-slider-click-target"
                   y1={innerHeight}
-                  strokeWidth={5}
+                  strokeWidth={6}
                   onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Max)}
                 />
                 <path d={sliderHandlePath} onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Max)} />

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -3,7 +3,7 @@
 .channel-row {
   .tf-editor-svg.dragging {
     &.basic {
-      cursor: pointer;
+      cursor: ew-resize;
     }
 
     &.advanced {
@@ -69,11 +69,16 @@
   .ramp-sliders {
     path {
       fill: var(--color-controlpanel-ramp-slider);
-      cursor: pointer;
+      cursor: ew-resize;
     }
 
     line {
       stroke: var(--color-controlpanel-ramp-slider);
+      cursor: ew-resize;
+
+      &.ramp-slider-click-target {
+        stroke: transparent;
+      }
     }
   }
 


### PR DESCRIPTION
Review time: tiny <5min

# Problem

Two minor, easy usability wins:
- Currently, when the control panel is collapsed, the buttons to change the panel to a different tab appear to do nothing:
![image](https://github.com/user-attachments/assets/2dcf081e-f77a-4df2-be84-82ed6fc7df16)
- Currently, in the "basic mode" transfer function editor, only the purple slider handles poking off the top and bottom of the plot are interactable; the purple lines are not:
![image](https://github.com/user-attachments/assets/3889c3d5-1231-4bad-83ae-a81426ea2779)


# Solution

- Now, clicking a tab while the control panel is collapsed also un-collapses the control panel
- The lines on the transfer function editor sliders are dashed and quite slim, so rather than make them clickable there's now a second invisible line on top of them with a heavier, solid stroke. Clicking on it has the same behavior as the current slider handles.
- Per @lynwilhelm's feedback, both the slider handles and the lines have a different cursor (this thing: <->)

### Steps to verify:

- `npm start`
- Try it!