### PR TITLE
Adjustable range in transfer function editor

### DIFF
--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -581,23 +581,27 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
           {/* plot axes */}
           <g ref={xAxisRef} className="axis" transform={`translate(0,${innerHeight})`} />
           <g ref={yAxisRef} className="axis" />
-          {/* control points */}
+          {/* "advanced mode" control points */}
           {controlPointCircles}
           {/* "basic mode" sliders */}
           {!props.useControlPoints && (
             <g className="ramp-sliders">
-              <g transform={`translate(${xScale(u8ToAbsolute(props.ramp[0], props.channelData))})`}>
-                <line y1={innerHeight} strokeDasharray="5,5" strokeWidth={2} />
-                <path
-                  d={sliderHandlePath}
-                  transform={`translate(0,${innerHeight}) rotate(180)`}
-                  onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Min)}
-                />
-              </g>
-              <g transform={`translate(${xScale(u8ToAbsolute(props.ramp[1], props.channelData))})`}>
-                <line y1={innerHeight} strokeDasharray="5,5" strokeWidth={2} />
-                <path d={sliderHandlePath} onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Max)} />
-              </g>
+              {plotMinU8 <= props.ramp[0] && props.ramp[0] <= plotMaxU8 && (
+                <g transform={`translate(${xScale(u8ToAbsolute(props.ramp[0], props.channelData))})`}>
+                  <line y1={innerHeight} strokeDasharray="5,5" strokeWidth={2} />
+                  <path
+                    d={sliderHandlePath}
+                    transform={`translate(0,${innerHeight}) rotate(180)`}
+                    onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Min)}
+                  />
+                </g>
+              )}
+              {plotMinU8 <= props.ramp[1] && props.ramp[1] <= plotMaxU8 && (
+                <g transform={`translate(${xScale(u8ToAbsolute(props.ramp[1], props.channelData))})`}>
+                  <line y1={innerHeight} strokeDasharray="5,5" strokeWidth={2} />
+                  <path d={sliderHandlePath} onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Max)} />
+                </g>
+              )}
             </g>
           )}
         </g>

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -582,7 +582,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
       {/* ----- MIN/MAX SPINBOXES ----- */}
       {!props.useControlPoints && (
         <div className="tf-editor-control-row ramp-row">
-          Ramp min/max:
+          Ramp min/max
           <InputNumber
             value={u8ToAbsolute(props.ramp[0], props.channelData)}
             onChange={(v) => v !== null && setRamp([absoluteToU8(v, props.channelData), props.ramp[1]])}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -579,6 +579,29 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
         </Checkbox>
       </div>
 
+      {/* ----- MIN/MAX SPINBOXES ----- */}
+      {!props.useControlPoints && (
+        <div className="tf-editor-control-row ramp-row">
+          Ramp min/max:
+          <InputNumber
+            value={u8ToAbsolute(props.ramp[0], props.channelData)}
+            onChange={(v) => v !== null && setRamp([absoluteToU8(v, props.channelData), props.ramp[1]])}
+            formatter={numberFormatter}
+            min={typeRange.min}
+            max={Math.min(u8ToAbsolute(props.ramp[1], props.channelData), typeRange.max)}
+            size="small"
+          />
+          <InputNumber
+            value={u8ToAbsolute(props.ramp[1], props.channelData)}
+            onChange={(v) => v !== null && setRamp([props.ramp[0], absoluteToU8(v, props.channelData)])}
+            formatter={numberFormatter}
+            min={Math.max(typeRange.min, u8ToAbsolute(props.ramp[0], props.channelData))}
+            max={typeRange.max}
+            size="small"
+          />
+        </div>
+      )}
+
       {/* ----- CONTROL POINT COLOR PICKER ----- */}
       {colorPickerPosition !== null && (
         <div className="tf-editor-popover">
@@ -639,7 +662,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
       </svg>
 
       {/* ----- PLOT RANGE ----- */}
-      <div className="tf-editor-numeric-input-row">
+      <div className="tf-editor-control-row plot-range-row">
         <span>
           <Checkbox checked={xScaleLockedToRange} onChange={(e) => setXScaleLockedToRange(e.target.checked)}>
             Lock to data range
@@ -659,34 +682,6 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
           </span>
         )}
       </div>
-
-      {/* ----- MIN/MAX SPINBOXES ----- */}
-      {!props.useControlPoints && (
-        <div className="tf-editor-numeric-input-row">
-          <span>
-            Min{" "}
-            <InputNumber
-              value={u8ToAbsolute(props.ramp[0], props.channelData)}
-              onChange={(v) => v !== null && setRamp([absoluteToU8(v, props.channelData), props.ramp[1]])}
-              formatter={numberFormatter}
-              min={typeRange.min}
-              max={Math.min(u8ToAbsolute(props.ramp[1], props.channelData), typeRange.max)}
-              size="small"
-            />
-          </span>
-          <span>
-            Max{" "}
-            <InputNumber
-              value={u8ToAbsolute(props.ramp[1], props.channelData)}
-              onChange={(v) => v !== null && setRamp([props.ramp[0], absoluteToU8(v, props.channelData)])}
-              formatter={numberFormatter}
-              min={Math.max(typeRange.min, u8ToAbsolute(props.ramp[0], props.channelData))}
-              max={typeRange.max}
-              size="small"
-            />
-          </span>
-        </div>
-      )}
 
       {/* ----- COLORIZE SLIDER ----- */}
       <SliderRow

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -196,15 +196,13 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   const { rawMin, rawMax, dtype } = props.channelData;
   const [xScaleLockedToRange, setXScaleLockedToRange] = useState<boolean>(true);
   const [xScaleMax, setXScaleMax] = useState<number>(DTYPE_RANGE[dtype][1]);
+  // data type can change when the channel loads
   useEffect(() => setXScaleMax(DTYPE_RANGE[dtype][1]), [dtype]);
 
   // d3 scales define the mapping between data and screen space (and do the heavy lifting of generating plot axes)
   /** `xScale` is in raw intensity range, not U8 range. We use `u8ToAbsolute` and `absoluteToU8` to translate to U8. */
   const xScale = useMemo(() => {
     const domain = xScaleLockedToRange ? [rawMin, rawMax] : [DTYPE_RANGE[dtype][0], xScaleMax];
-    if (!xScaleLockedToRange) {
-      console.log(rawMin, rawMax, dtype);
-    }
     return d3.scaleLinear().domain(domain).range([0, innerWidth]);
   }, [innerWidth, rawMin, rawMax, dtype, xScaleLockedToRange, xScaleMax]);
   const yScale = useMemo(() => d3.scaleLinear().domain([0, 1]).range([innerHeight, 0]), [innerHeight]);

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -471,8 +471,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
       const end = Math.min(numBins, Math.floor(plotMaxU8));
       const binLengthsToRender = binLengths.slice(start, end);
 
-      // TODO this isn't right anymore
-      const barWidth = innerWidth / numBins;
+      const barWidth = innerWidth / (plotMaxU8 - plotMinU8);
       const binScale = d3.scaleLog().domain([0.1, max]).range([innerHeight, 0]).base(2).clamp(true);
 
       d3.select(el)

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -683,7 +683,6 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
               min={Math.max(typeRange.min, u8ToAbsolute(props.ramp[0], props.channelData))}
               max={typeRange.max}
               size="small"
-              width={45}
             />
           </span>
         </div>

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -596,7 +596,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
                   />
                 </g>
               )}
-              {plotMinU8 <= props.ramp[1] && props.ramp[1] <= plotMaxU8 && (
+              {plotMinU8 <= props.ramp[0] && props.ramp[0] <= plotMaxU8 && (
                 <g transform={`translate(${xScale(u8ToAbsolute(props.ramp[1], props.channelData))})`}>
                   <line y1={innerHeight} strokeDasharray="5,5" strokeWidth={2} />
                   <path d={sliderHandlePath} onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Max)} />
@@ -621,8 +621,8 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
               value={xScaleMax}
               onChange={(v) => v !== null && setXScaleMax(v)}
               formatter={numberFormatter}
-              min={DTYPE_RANGE[props.channelData.dtype].min}
-              max={DTYPE_RANGE[props.channelData.dtype].max}
+              min={typeRange.min}
+              max={typeRange.max}
               size="small"
             />
           </span>
@@ -638,8 +638,8 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
               value={u8ToAbsolute(props.ramp[0], props.channelData)}
               onChange={(v) => v !== null && setRamp([absoluteToU8(v, props.channelData), props.ramp[1]])}
               formatter={numberFormatter}
-              min={0}
-              max={Math.min(u8ToAbsolute(props.ramp[1], props.channelData), props.channelData.rawMax)}
+              min={typeRange.min}
+              max={Math.min(u8ToAbsolute(props.ramp[1], props.channelData), typeRange.max)}
               size="small"
             />
           </span>
@@ -649,8 +649,8 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
               value={u8ToAbsolute(props.ramp[1], props.channelData)}
               onChange={(v) => v !== null && setRamp([props.ramp[0], absoluteToU8(v, props.channelData)])}
               formatter={numberFormatter}
-              min={Math.max(0, u8ToAbsolute(props.ramp[0], props.channelData))}
-              max={props.channelData.rawMax}
+              min={Math.max(typeRange.min, u8ToAbsolute(props.ramp[0], props.channelData))}
+              max={typeRange.max}
               size="small"
               width={45}
             />

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -152,6 +152,10 @@ const createPointOnRangeBoundary = (outOfRangePt: ControlPoint, inRangePt: Contr
   return { x, opacity, color };
 };
 
+/**
+ * Ensures the list of `controlPoints` exactly covers the range from `plotMin` to `plotMax` by removing any
+ * out-of-range points and adding new points right at the edges of the range.
+ */
 const fitControlPointsToRange = (controlPoints: ControlPoint[], plotMin: number, plotMax: number): ControlPoint[] => {
   const points = controlPoints.slice();
 

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -42,6 +42,17 @@ const TFEDITOR_MARGINS = {
 
 const MOUSE_EVENT_BUTTONS_PRIMARY = 1;
 
+const DTYPE_RANGE: { [T in Channel["dtype"]]: [number, number] } = {
+  int8: [-Math.pow(2, 7), Math.pow(2, 7) - 1],
+  int16: [-Math.pow(2, 15), Math.pow(2, 15) - 1],
+  int32: [-Math.pow(2, 31), Math.pow(2, 31) - 1],
+  uint8: [0, Math.pow(2, 8) - 1],
+  uint16: [0, Math.pow(2, 16) - 1],
+  uint32: [0, Math.pow(2, 32) - 1],
+  float32: [-Infinity, Infinity],
+  float64: [-Infinity, Infinity],
+};
+
 const enum TfEditorRampSliderHandle {
   Min = "min",
   Max = "max",

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -590,6 +590,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
             min={typeRange.min}
             max={Math.min(u8ToAbsolute(props.ramp[1], props.channelData), typeRange.max)}
             size="small"
+            controls={false}
           />
           <InputNumber
             value={u8ToAbsolute(props.ramp[1], props.channelData)}
@@ -598,6 +599,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
             min={Math.max(typeRange.min, u8ToAbsolute(props.ramp[0], props.channelData))}
             max={typeRange.max}
             size="small"
+            controls={false}
           />
         </div>
       )}
@@ -690,6 +692,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
               min={typeRange.min}
               max={typeRange.max}
               size="small"
+              controls={false}
             />
           </span>
         )}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -5,12 +5,7 @@ import "nouislider/distribute/nouislider.css";
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { ColorResult, SketchPicker } from "react-color";
 
-import {
-  LUT_MAX_PERCENTILE,
-  LUT_MIN_PERCENTILE,
-  TFEDITOR_DEFAULT_COLOR,
-  TFEDITOR_MAX_BIN,
-} from "../../shared/constants";
+import { LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE, TFEDITOR_DEFAULT_COLOR } from "../../shared/constants";
 import {
   ColorArray,
   colorArrayToObject,
@@ -49,8 +44,10 @@ const DTYPE_RANGE: { [T in Channel["dtype"]]: [number, number] } = {
   uint8: [0, Math.pow(2, 8) - 1],
   uint16: [0, Math.pow(2, 16) - 1],
   uint32: [0, Math.pow(2, 32) - 1],
-  float32: [-Infinity, Infinity],
-  float64: [-Infinity, Infinity],
+  // These are obviously not the actual min and max representable values for floats, but the actual ones (`-Infinity`
+  // and `Infinity`) would give us nonsense. These may also produce nonsense, but these types should be rare anyways.
+  float32: [0, Math.pow(2, 8) - 1],
+  float64: [0, Math.pow(2, 8) - 1],
 };
 
 const enum TfEditorRampSliderHandle {

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -2,7 +2,7 @@ import { Channel, ControlPoint, Histogram, Lut } from "@aics/vole-core";
 import { Button, Checkbox, InputNumber, Tooltip } from "antd";
 import * as d3 from "d3";
 import "nouislider/distribute/nouislider.css";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ColorResult, SketchPicker } from "react-color";
 
 import { LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE, TFEDITOR_DEFAULT_COLOR } from "../../shared/constants";
@@ -191,18 +191,22 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   const [colorPickerPosition, setColorPickerPosition] = useState<[number, number] | null>(null);
   const lastColorRef = useRef<ColorArray>(TFEDITOR_DEFAULT_COLOR);
 
-  const [xScaleLockedToRange, setXScaleLockedToRange] = useState<boolean>(true);
-  const [xScaleMax, setXScaleMax] = useState<number>(DTYPE_RANGE[props.channelData.dtype][1]);
-
   const svgRef = useRef<SVGSVGElement>(null); // need access to SVG element to measure mouse position
+
+  const { rawMin, rawMax, dtype } = props.channelData;
+  const [xScaleLockedToRange, setXScaleLockedToRange] = useState<boolean>(true);
+  const [xScaleMax, setXScaleMax] = useState<number>(DTYPE_RANGE[dtype][1]);
+  useEffect(() => setXScaleMax(DTYPE_RANGE[dtype][1]), [dtype]);
 
   // d3 scales define the mapping between data and screen space (and do the heavy lifting of generating plot axes)
   /** `xScale` is in raw intensity range, not U8 range. We use `u8ToAbsolute` and `absoluteToU8` to translate to U8. */
   const xScale = useMemo(() => {
-    const { rawMin, rawMax, dtype } = props.channelData;
     const domain = xScaleLockedToRange ? [rawMin, rawMax] : [DTYPE_RANGE[dtype][0], xScaleMax];
+    if (!xScaleLockedToRange) {
+      console.log(rawMin, rawMax, dtype);
+    }
     return d3.scaleLinear().domain(domain).range([0, innerWidth]);
-  }, [innerWidth, props.channelData, xScaleLockedToRange, xScaleMax]);
+  }, [innerWidth, rawMin, rawMax, dtype, xScaleLockedToRange, xScaleMax]);
   const yScale = useMemo(() => d3.scaleLinear().domain([0, 1]).range([innerHeight, 0]), [innerHeight]);
 
   const mouseEventToControlPointValues = (event: MouseEvent | React.MouseEvent): [number, number] => {
@@ -525,7 +529,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
         </g>
       </svg>
 
-      {/* ----- PLOT RAMGE ----- */}
+      {/* ----- PLOT RANGE ----- */}
       <div className="tf-editor-numeric-input-row">
         <span>
           <Checkbox checked={xScaleLockedToRange} onChange={(e) => setXScaleLockedToRange(e.target.checked)}>

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -623,7 +623,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
                   />
                 </g>
               )}
-              {plotMinU8 <= props.ramp[0] && props.ramp[0] <= plotMaxU8 && (
+              {plotMinU8 <= props.ramp[1] && props.ramp[1] <= plotMaxU8 && (
                 <g transform={`translate(${xScale(u8ToAbsolute(props.ramp[1], props.channelData))})`}>
                   <line y1={innerHeight} strokeDasharray="5,5" strokeWidth={2} />
                   <path d={sliderHandlePath} onPointerDown={() => setDraggedPointIdx(TfEditorRampSliderHandle.Max)} />

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -175,7 +175,7 @@ const fitControlPointsToRange = (controlPoints: ControlPoint[], plotMin: number,
 
   if (lastPoint.x < plotMax) {
     // If the control points don't go all the way to the max, add a new point at the max.
-    points.push({ ...firstPoint, x: plotMax });
+    points.push({ ...lastPoint, x: plotMax });
   } else {
     // If some control points are out of range, remove those points...
     let outOfRangePoint: ControlPoint | undefined = undefined;

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -64,7 +64,7 @@
 
   .line {
     stroke: $light-gray;
-    stroke-width: 1.5px;
+    stroke-width: 1px;
   }
 
   .ramp-sliders {

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -30,6 +30,7 @@
     align-items: center;
     justify-content: space-between;
     margin-bottom: 20px;
+    min-height: 24px;
     color: var(--color-controlpanel-text);
 
     .ant-input-number {

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -25,13 +25,21 @@
     bottom: 0;
   }
 
-  .tf-editor-numeric-input-row {
+  .tf-editor-control-row {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 20px;
-    min-height: 24px;
     color: var(--color-controlpanel-text);
+    align-items: center;
+    min-height: 24px;
+
+    &.ramp-row {
+      gap: 6px;
+      margin-top: 15px;
+    }
+
+    &.plot-range-row {
+      justify-content: space-between;
+      margin-bottom: 20px;
+    }
 
     .ant-input-number {
       border-color: var(--color-button-tertiary-outline);

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -35,7 +35,7 @@
 
     .ant-input-number {
       border-color: var(--color-button-tertiary-outline);
-      width: 60px;
+      width: 72px;
     }
   }
 

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -44,6 +44,10 @@
     .ant-input-number {
       border-color: var(--color-button-tertiary-outline);
       width: 72px;
+
+      input {
+        text-align: right;
+      }
     }
   }
 


### PR DESCRIPTION
Review size: medium

# Problem

Closes #373: scientists want channel histograms in the transfer function editor to be displayed in a consistent, configurable range. The current behavior, where the ends of the plot are fixed to the min and max of the data per-frame, is unacceptable.

# Solution

- Add new UI elements which afford a minimal amount of control over the range of the plot. These controls may later be upgraded with designs that incorporate feedback from this first iteration, but this first iteration should at least be sufficient to meet scientists' needs.
- Now that the range of the plot can be changed, the potential for elements in the plot to render outside the bounds of the plot is much higher. A lot of the code changes here are about ensuring those elements (histogram bars, control points, the line and gradient connecting control points, etc.) clip properly against the min and max of the plot.
- There's also a bit of extra polish in here, like making tick marks on the X axis a bit smarter.
- State for the range of the plot is currently held by the `TfEditor` component which contains the plot itself. This is problematic because that state is reset whenever the component is unmounted and mounted again, including when the channel controls are collapsed or the user navigates to another tab of the control panel. A future PR (#381) will lift this state into the `ChannelState` type which is persistent while the `App` component is mounted.

### Screenshots

![image](https://github.com/user-attachments/assets/2f44e4f1-f4ce-4e88-92f9-151a4b99af71)
