### PR TITLE
Store multiscene collections in local storage

### DIFF
--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -9,7 +9,7 @@ const LocalStorageReceiver: React.FC = () => {
         return;
       }
 
-      window.localStorage.setItem("scenes", encodeImageUrlProp(e.data));
+      window.localStorage.setItem("url", encodeImageUrlProp(e.data));
       (e.source as Window)?.postMessage("SUCCESS", e.origin);
     };
 

--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -3,7 +3,12 @@ import React from "react";
 const LocalStorageReceiver: React.FC = () => {
   React.useLayoutEffect(() => {
     const receiveMessage = (e: MessageEvent) => {
-      console.log(e.data);
+      if (e.origin === window.location.origin) {
+        return;
+      }
+
+      window.localStorage.setItem("scenes", e.data);
+      (e.source as Window)?.postMessage("SUCCESS", e.origin);
     };
 
     window.addEventListener("message", receiveMessage);

--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const LocalStorageReceiver: React.FC = () => {
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const receiveMessage = (e: MessageEvent) => {
       console.log(e.data);
     };

--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 
+import { MultisceneUrls } from "../src/aics-image-viewer/components/App/types.ts";
+import { MetadataRecord } from "../src/aics-image-viewer/shared/types.ts";
 import { encodeImageUrlProp } from "../website/utils/url_utils.ts";
+
+type Message = MultisceneUrls & {
+  meta?: MetadataRecord | MetadataRecord[];
+};
 
 const LocalStorageReceiver: React.FC = () => {
   React.useLayoutEffect(() => {
@@ -9,9 +15,11 @@ const LocalStorageReceiver: React.FC = () => {
         return;
       }
 
-      window.localStorage.setItem("url", encodeImageUrlProp(e.data));
+      const message = e.data as Message;
+
+      window.localStorage.setItem("url", encodeImageUrlProp(message));
       if (e.data.meta !== undefined) {
-        window.localStorage.setItem("meta", JSON.stringify(e.data.meta));
+        window.localStorage.setItem("meta", JSON.stringify(message.meta));
       } else {
         window.localStorage.removeItem("meta");
       }

--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -17,6 +17,7 @@ const LocalStorageReceiver: React.FC = () => {
 
       const message = e.data as Message;
       if (message.scenes === undefined) {
+        (e.source as Window)?.postMessage("ERROR: no scenes", e.origin);
         return;
       }
 

--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -16,6 +16,9 @@ const LocalStorageReceiver: React.FC = () => {
       }
 
       const message = e.data as Message;
+      if (message.scenes === undefined) {
+        return;
+      }
 
       window.localStorage.setItem("url", encodeImageUrlProp(message));
       if (e.data.meta !== undefined) {

--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -10,6 +10,11 @@ const LocalStorageReceiver: React.FC = () => {
       }
 
       window.localStorage.setItem("url", encodeImageUrlProp(e.data));
+      if (e.data.meta !== undefined) {
+        window.localStorage.setItem("meta", JSON.stringify(e.data.meta));
+      } else {
+        window.localStorage.removeItem("meta");
+      }
       (e.source as Window)?.postMessage("SUCCESS", e.origin);
     };
 

--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { encodeImageUrlProp } from "../website/utils/url_utils.ts";
+
 const LocalStorageReceiver: React.FC = () => {
   React.useLayoutEffect(() => {
     const receiveMessage = (e: MessageEvent) => {
@@ -7,7 +9,7 @@ const LocalStorageReceiver: React.FC = () => {
         return;
       }
 
-      window.localStorage.setItem("scenes", e.data);
+      window.localStorage.setItem("scenes", encodeImageUrlProp(e.data));
       (e.source as Window)?.postMessage("SUCCESS", e.origin);
     };
 

--- a/public/LocalStorageReceiver.tsx
+++ b/public/LocalStorageReceiver.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+const LocalStorageReceiver: React.FC = () => {
+  React.useEffect(() => {
+    const receiveMessage = (e: MessageEvent) => {
+      console.log(e.data);
+    };
+
+    window.addEventListener("message", receiveMessage);
+    return () => window.removeEventListener("message", receiveMessage);
+  }, []);
+
+  return null;
+};
+
+export default LocalStorageReceiver;

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -38,10 +38,7 @@ const routes: RouteObject[] = [
   },
   {
     path: "viewer",
-    lazy: async () => {
-      console.log("lazy");
-      return { Component: (await import("../website/components/AppWrapper")).default };
-    },
+    lazy: async () => ({ Component: (await import("../website/components/AppWrapper")).default }),
     errorElement: <ErrorPage />,
   },
   {

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -1,16 +1,17 @@
-import React from "react";
+import React, { lazy } from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import { decodeGitHubPagesUrl, isEncodedPathUrl, tryRemoveHashRouting } from "../website/utils/gh_route_utils";
 
 import StyleProvider from "../src/aics-image-viewer/components/StyleProvider";
-// Components
-import AppWrapper from "../website/components/AppWrapper";
-import ErrorPage from "../website/components/ErrorPage";
-import LandingPage from "../website/components/LandingPage";
 
 import "./App.css";
+
+// Components
+const AppWrapper = lazy(() => import("../website/components/AppWrapper"));
+const ErrorPage = lazy(() => import("../website/components/ErrorPage"));
+const LandingPage = lazy(() => import("../website/components/LandingPage"));
 
 // vars filled at build time using webpack DefinePlugin
 console.log(`vole-app ${VOLEAPP_BUILD_ENVIRONMENT} build`);
@@ -31,6 +32,7 @@ if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {
   window.history.replaceState(null, "", newRelativePath);
 }
 
+// TODO these components are now lazy loaded. Should they get `Suspense`s around them? What should we fall back to?
 const routes = [
   {
     path: "/",

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -1,18 +1,14 @@
-import React, { lazy } from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, type RouteObject, RouterProvider } from "react-router-dom";
 
 import { decodeGitHubPagesUrl, isEncodedPathUrl, tryRemoveHashRouting } from "../website/utils/gh_route_utils";
 
 import StyleProvider from "../src/aics-image-viewer/components/StyleProvider";
+import ErrorPage from "../website/components/ErrorPage";
 import LocalStorageReceiver from "./LocalStorageReceiver";
 
 import "./App.css";
-
-// Components
-const AppWrapper = lazy(() => import("../website/components/AppWrapper"));
-const ErrorPage = lazy(() => import("../website/components/ErrorPage"));
-const LandingPage = lazy(() => import("../website/components/LandingPage"));
 
 // vars filled at build time using webpack DefinePlugin
 console.log(`vole-app ${VOLEAPP_BUILD_ENVIRONMENT} build`);
@@ -37,17 +33,20 @@ if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {
 const routes: RouteObject[] = [
   {
     path: "/",
-    Component: LandingPage,
+    lazy: async () => ({ Component: (await import("../website/components/LandingPage")).default }),
     errorElement: <ErrorPage />,
   },
   {
     path: "viewer",
-    Component: AppWrapper,
+    lazy: async () => {
+      console.log("lazy");
+      return { Component: (await import("../website/components/AppWrapper")).default };
+    },
     errorElement: <ErrorPage />,
   },
   {
     path: "write_storage",
-    Component: LocalStorageReceiver,
+    element: <LocalStorageReceiver />,
     errorElement: <ErrorPage />,
   },
 ];

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -1,10 +1,11 @@
 import React, { lazy } from "react";
 import { createRoot } from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, type RouteObject, RouterProvider } from "react-router-dom";
 
 import { decodeGitHubPagesUrl, isEncodedPathUrl, tryRemoveHashRouting } from "../website/utils/gh_route_utils";
 
 import StyleProvider from "../src/aics-image-viewer/components/StyleProvider";
+import LocalStorageReceiver from "./LocalStorageReceiver";
 
 import "./App.css";
 
@@ -33,15 +34,20 @@ if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {
 }
 
 // TODO these components are now lazy loaded. Should they get `Suspense`s around them? What should we fall back to?
-const routes = [
+const routes: RouteObject[] = [
   {
     path: "/",
-    element: <LandingPage />,
+    Component: LandingPage,
     errorElement: <ErrorPage />,
   },
   {
     path: "viewer",
-    element: <AppWrapper />,
+    Component: AppWrapper,
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: "write_storage",
+    Component: LocalStorageReceiver,
     errorElement: <ErrorPage />,
   },
 ];

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -557,20 +557,22 @@ const App: React.FC<AppProps> = (props) => {
       imageMetadata = metadataFormatter(imageMetadata);
     }
 
-    // If metadata is an array, try to assume it contains metadata for each scene
-    // TODO just make top-level metadata arrays illegal
-    let sceneMeta = metadata;
-    if (Array.isArray(metadata) && metadata.length === numScenes) {
-      const maybeSceneMeta = metadata[viewerState.current.scene];
-      if (typeof maybeSceneMeta === "object" && maybeSceneMeta !== null) {
-        sceneMeta = maybeSceneMeta;
+    let sceneMeta: MetadataRecord | undefined;
+    if (Array.isArray(metadata)) {
+      // If metadata is an array, try to index it by scene
+      if (metadata.length >= numScenes) {
+        sceneMeta = metadata[viewerState.current.scene];
+      } else {
+        sceneMeta = metadata[0];
       }
+    } else {
+      sceneMeta = metadata;
     }
 
     if (imageMetadata && Object.keys(imageMetadata).length > 0) {
       return { Image: imageMetadata, ...sceneMeta };
     } else {
-      return metadata || {};
+      return sceneMeta ?? {};
     }
   }, [props.metadata, props.metadataFormatter, image]);
 

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -557,8 +557,18 @@ const App: React.FC<AppProps> = (props) => {
       imageMetadata = metadataFormatter(imageMetadata);
     }
 
+    // If metadata is an array, try to assume it contains metadata for each scene
+    // TODO just make top-level metadata arrays illegal
+    let sceneMeta = metadata;
+    if (Array.isArray(metadata) && metadata.length === numScenes) {
+      const maybeSceneMeta = metadata[viewerState.current.scene];
+      if (typeof maybeSceneMeta === "object" && maybeSceneMeta !== null) {
+        sceneMeta = maybeSceneMeta;
+      }
+    }
+
     if (imageMetadata && Object.keys(imageMetadata).length > 0) {
-      return { Image: imageMetadata, ...metadata };
+      return { Image: imageMetadata, ...sceneMeta };
     } else {
       return metadata || {};
     }

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -64,7 +64,7 @@ export interface AppProps {
     translation: [number, number, number];
     rotation: [number, number, number];
   };
-  metadata?: MetadataRecord;
+  metadata?: MetadataRecord | MetadataRecord[];
 
   view3dRef?: MutableRefObject<View3d | null>;
   metadataFormatter?: (metadata: MetadataRecord) => MetadataRecord;

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -2,19 +2,21 @@ import { RightOutlined } from "@ant-design/icons";
 import React from "react";
 
 import { MetadataEntry, MetadataRecord } from "../../shared/types";
+
 import "./styles.css";
 
 type MetadataTableProps = {
-  metadata: MetadataRecord;
+  metadata: MetadataRecord | MetadataEntry[];
   topLevel?: boolean;
 };
 
 type CollapsibleCategoryProps = {
-  metadata: MetadataRecord;
+  metadata: MetadataRecord | MetadataEntry[];
   title: string;
 };
 
-const isCategory = (entry: MetadataEntry): entry is MetadataRecord => typeof entry === "object" && entry !== null;
+const isCategory = (entry: MetadataEntry): entry is MetadataRecord | MetadataEntry[] =>
+  typeof entry === "object" && entry !== null;
 
 const sortCategoriesFirst = (entry: MetadataEntry): MetadataEntry => {
   if (!isCategory(entry) || Array.isArray(entry)) {

--- a/src/aics-image-viewer/shared/types.ts
+++ b/src/aics-image-viewer/shared/types.ts
@@ -1,4 +1,5 @@
 import { CSSProperties } from "react";
+
 import { ViewMode } from "./enums";
 
 export type AxisName = "x" | "y" | "z";
@@ -14,5 +15,5 @@ export type IsosurfaceFormat = "GLTF" | "STL";
 
 export type Styles = { [key: string]: CSSProperties };
 
-export type MetadataEntry = string | number | boolean | MetadataRecord | null | undefined;
-export type MetadataRecord = { [key: string]: MetadataEntry } | MetadataEntry[];
+export type MetadataEntry = string | number | boolean | MetadataRecord | MetadataEntry[] | null | undefined;
+export type MetadataRecord = { [key: string]: MetadataEntry };

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -971,7 +971,8 @@ export async function parseViewerUrlParams(urlSearchParams: URLSearchParams): Pr
 
   // Parse data sources (URL or dataset/id pair)
   if (params.url) {
-    const urlParam = params.url === URL_FETCH_FROM_STORAGE ? (localStorage.getItem("url") ?? params.url) : params.url;
+    const getFromStorage = params.url === URL_FETCH_FROM_STORAGE;
+    const urlParam = getFromStorage ? (localStorage.getItem("url") ?? params.url) : params.url;
     // split encoded url into a list of one or more scenes...
     const sceneUrls = tryDecodeURLList(urlParam, /[+ ]/) ?? [urlParam];
     // ...and each scene into a list of multiple sources, if any.
@@ -983,6 +984,11 @@ export async function parseViewerUrlParams(urlSearchParams: URLSearchParams): Pr
     // Strip away unneeded structure from final prop (don't represent a multiscene or multi-source image unless needed)
     const imageUrls: string | string[] | MultisceneUrls =
       scenes.length > 1 ? { scenes } : firstScene.length > 1 ? firstScene : firstScene[0];
+
+    if (getFromStorage) {
+      const metadataJson = localStorage.getItem("meta");
+      args.metadata = metadataJson !== null ? JSON.parse(metadataJson) : undefined;
+    }
 
     args.cellId = "1";
     args.imageUrl = imageUrls;

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -28,6 +28,7 @@ export const ENCODED_COLON_REGEX = /%3A/g;
 const DEFAULT_CONTROL_POINT_COLOR: [number, number, number] = [255, 255, 255];
 const DEFAULT_CONTROL_POINT_COLOR_CODE = "1";
 
+/** If the `url` query param equals this, parse image url(s) and metadata from local storage instead of params */
 const URL_FETCH_FROM_STORAGE = "storage";
 
 // TODO: refactor regexes to be composed of one another rather than duplicating code


### PR DESCRIPTION
Review time: small-medium

# Problem

Scientists want to be able to open a selection of files in BioFile Finder as a multi-scene collection in Vol-E. Currently, collections of scenes to open are encoded as a delimited list of URLs in a query parameter in the app URL. This presents a couple problems for the BFF use case:
- Since users can select an arbitrary number of images in BFF, they could very easily create unworkably long Vol-E URLs.
- We want to bring metadata for each scene along from BFF as well. We don't currently have a way to parse metadata out of a query parameter, and even if we did, this could create unworkably long URLs from even a single scene!

# Solution

For this use case, we've decided to put scene URLs and metadata in Vol-E's *local storage* instead. This presents a new wrinkle: sites can't write to a different site's local storage. But they can send a message and have the site write it themselves. So the whole process looks like:
- BFF `iframe`s in Vol-E
- BFF calls `postMessage` to transfer scenes and metadata
- Vol-E receives that message, drops the scenes and metadata in its own local storage, and responds that it's received the message
- BFF opens a new Vol-E window with a query parameter telling Vol-E to open scenes from local storage
- Vol-E does that

So this change implements the Vol-E side of that procedure: receiving messages and writing/reading local storage.

## Change summary

- Add a new route to Vol-E, pointing to a component that renders nothing but listens to messages from external sites and writes local storage
- Ensure that other routes are lazy-loaded so that, when we access that route, the entire Vol-E viewer doesn't come along for the ride
- Add code to pull URLs and metadata from local storage when the `url` query parameter is set to `storage`
- Tweak how the `metadata` prop is interpreted: if the top-level of the metadata object is an array, assume that it's a list of metadata objects for each scene, not the metadata for a single image.