### PR TITLE
Persistent transfer function editor range

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -20,6 +20,7 @@ import {
   AXIS_MARGIN_DEFAULT,
   CACHE_MAX_SIZE,
   CONTROL_PANEL_CLOSE_WIDTH,
+  DTYPE_RANGE,
   getDefaultChannelColor,
   getDefaultViewerState,
   QUEUE_MAX_LOW_PRIORITY_SIZE,
@@ -269,7 +270,13 @@ const App: React.FC<AppProps> = (props) => {
     ) {
       const viewerChannelSettings = getCurrentViewerChannelSettings();
       const { ramp, controlPoints } = initializeLut(aimg, channelIndex, viewerChannelSettings);
-      changeChannelSetting(channelIndex, { controlPoints: controlPoints, ramp: controlPointsToRamp(ramp) });
+
+      changeChannelSetting(channelIndex, {
+        controlPoints: controlPoints,
+        ramp: controlPointsToRamp(ramp),
+        // set the default range of the transfer function editor to cover the full range of the data type
+        plotMax: DTYPE_RANGE[thisChannel.dtype].max,
+      });
       onResetChannel(channelIndex);
     } else {
       // try not to update lut from here if we are in play mode
@@ -281,8 +288,8 @@ const App: React.FC<AppProps> = (props) => {
       const oldRange = channelRangesRef.current[channelIndex];
       if (thisChannelsSettings.useControlPoints) {
         // control points were just automatically remapped - update in state
-        // now manually remap ramp using the channel's old range
         const rampControlPoints = rampToControlPoints(thisChannelsSettings.ramp);
+        // now manually remap ramp using the channel's old range
         const remappedRampControlPoints = remapControlPointsForChannel(rampControlPoints, oldRange, thisChannel);
         changeChannelSetting(channelIndex, {
           ramp: controlPointsToRamp(remappedRampControlPoints),

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -86,7 +86,8 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
   );
 
   const createTFEditor = (): React.ReactNode => {
-    const { controlPoints, colorizeEnabled, colorizeAlpha, useControlPoints, ramp } = channelState;
+    const { controlPoints, colorizeEnabled, colorizeAlpha, useControlPoints, ramp, lockPlotToDataRange, plotMax } =
+      channelState;
     return (
       <TfEditor
         id={"TFEditor" + index}
@@ -99,6 +100,8 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
         colorizeAlpha={colorizeAlpha}
         useControlPoints={useControlPoints}
         ramp={ramp}
+        lockPlotToDataRange={lockPlotToDataRange}
+        plotMax={plotMax}
       />
     );
   };

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -2,10 +2,10 @@ import { Channel, ControlPoint, Histogram, Lut } from "@aics/vole-core";
 import { Button, Checkbox, InputNumber, Tooltip } from "antd";
 import * as d3 from "d3";
 import "nouislider/distribute/nouislider.css";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { ColorResult, SketchPicker } from "react-color";
 
-import { LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE, TFEDITOR_DEFAULT_COLOR } from "../../shared/constants";
+import { DTYPE_RANGE, LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE, TFEDITOR_DEFAULT_COLOR } from "../../shared/constants";
 import {
   ColorArray,
   colorArrayToObject,
@@ -45,19 +45,6 @@ const TFEDITOR_MARGINS = {
 };
 
 const MOUSE_EVENT_BUTTONS_PRIMARY = 1;
-
-const DTYPE_RANGE: { [T in Channel["dtype"]]: { min: number; max: number } } = {
-  int8: { min: -Math.pow(2, 7), max: Math.pow(2, 7) - 1 },
-  int16: { min: -Math.pow(2, 15), max: Math.pow(2, 15) - 1 },
-  int32: { min: -Math.pow(2, 31), max: Math.pow(2, 31) - 1 },
-  uint8: { min: 0, max: Math.pow(2, 8) - 1 },
-  uint16: { min: 0, max: Math.pow(2, 16) - 1 },
-  uint32: { min: 0, max: Math.pow(2, 32) - 1 },
-  // These are obviously not the actual min and max representable values for floats, but the actual ones (`-Infinity`
-  // and `Infinity`) would give us nonsense. These may also produce nonsense, but these types should be rare anyways.
-  float32: { min: 0, max: Math.pow(2, 8) - 1 },
-  float64: { min: 0, max: Math.pow(2, 8) - 1 },
-};
 
 const enum TfEditorRampSliderHandle {
   Min = "min",
@@ -271,8 +258,6 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   const typeRange = DTYPE_RANGE[dtype];
   const [xScaleLockedToRange, setXScaleLockedToRange] = useState<boolean>(true);
   const [xScaleMax, setXScaleMax] = useState<number>(typeRange.max);
-  // data type can change when the channel loads
-  useEffect(() => setXScaleMax(typeRange.max), [typeRange]);
 
   // d3 scales define the mapping between data and screen space (and do the heavy lifting of generating plot axes)
   /** `xScale` is in raw intensity range, not U8 range. We use `u8ToAbsolute` and `absoluteToU8` to translate to U8. */

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -69,6 +69,8 @@ export interface ChannelState {
   ramp: [number, number];
   useControlPoints: boolean;
   controlPoints: ControlPoint[];
+  lockPlotToDataRange: boolean;
+  plotMax: number;
 }
 
 export type ChannelStateKey = keyof ChannelState;

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -210,7 +210,7 @@ export const getDefaultChannelState = (index: number = 0): ChannelState => {
       { x: 0, opacity: 0, color: [255, 255, 255] },
       { x: 255, opacity: 1, color: [255, 255, 255] },
     ],
-    lockPlotToDataRange: false,
+    lockPlotToDataRange: true,
     plotMax: TFEDITOR_MAX_BIN,
   };
 };

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -210,5 +210,7 @@ export const getDefaultChannelState = (index: number = 0): ChannelState => {
       { x: 0, opacity: 0, color: [255, 255, 255] },
       { x: 255, opacity: 1, color: [255, 255, 255] },
     ],
+    lockPlotToDataRange: false,
+    plotMax: TFEDITOR_MAX_BIN,
   };
 };

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -1,4 +1,4 @@
-import { CameraState } from "@aics/vole-core";
+import type { CameraState, Channel } from "@aics/vole-core";
 
 import { ChannelState, ViewerState } from "../components/ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "./enums";
@@ -32,6 +32,20 @@ export const TFEDITOR_MAX_BIN = 255;
 export const CACHE_MAX_SIZE = 1_000_000_000;
 export const QUEUE_MAX_SIZE = 10;
 export const QUEUE_MAX_LOW_PRIORITY_SIZE = 4;
+
+/** Maps channel data types to their minimum and maximum values */
+export const DTYPE_RANGE: { [T in Channel["dtype"]]: { min: number; max: number } } = {
+  int8: { min: -Math.pow(2, 7), max: Math.pow(2, 7) - 1 },
+  int16: { min: -Math.pow(2, 15), max: Math.pow(2, 15) - 1 },
+  int32: { min: -Math.pow(2, 31), max: Math.pow(2, 31) - 1 },
+  uint8: { min: 0, max: Math.pow(2, 8) - 1 },
+  uint16: { min: 0, max: Math.pow(2, 16) - 1 },
+  uint32: { min: 0, max: Math.pow(2, 32) - 1 },
+  // These are obviously not the actual min and max representable values for floats, but the actual ones (`-Infinity`
+  // and `Infinity`) would give us nonsense. These may also produce nonsense, but these types should be rare anyways.
+  float32: { min: 0, max: Math.pow(2, 8) - 1 },
+  float64: { min: 0, max: Math.pow(2, 8) - 1 },
+};
 
 export const PRESET_COLORS_1: ColorArray[] = [
   [190, 68, 171],

--- a/src/aics-image-viewer/shared/utils/viewerState.ts
+++ b/src/aics-image-viewer/shared/utils/viewerState.ts
@@ -82,5 +82,7 @@ export function initializeOneChannelSetting(
     useControlPoints: initSettings.controlPointsEnabled ?? defaultChannelState.useControlPoints,
     controlPoints: initSettings.controlPoints ?? defaultChannelState.controlPoints,
     ramp: initSettings.ramp ?? defaultChannelState.ramp,
+    lockPlotToDataRange: defaultChannelState.lockPlotToDataRange,
+    plotMax: defaultChannelState.plotMax,
   };
 }

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -246,6 +246,8 @@ describe("Channel state serialization", () => {
       { x: 255, opacity: 1.0, color: [255, 255, 255] },
     ],
     ramp: [0, 255],
+    lockPlotToDataRange: true,
+    plotMax: 255,
   };
   const DEFAULT_SERIALIZED_CHANNEL_STATE: ViewerChannelSettingParams = {
     col: "ff0000",
@@ -380,6 +382,8 @@ describe("Channel state serialization", () => {
         useControlPoints: false,
         controlPoints: [],
         ramp: [0, 255],
+        lockPlotToDataRange: true,
+        plotMax: 255,
       };
       const serializedCustomChannelState: Required<Omit<ViewerChannelSettingParams, "lut">> = {
         col: "03ff9d",
@@ -821,6 +825,8 @@ describe("serializeViewerUrlParams", () => {
           { x: 1, opacity: 1, color: [255, 0, 0] },
         ],
         ramp: [-10, 260.1],
+        lockPlotToDataRange: true,
+        plotMax: 255,
       },
       {
         name: "channel1",
@@ -841,6 +847,8 @@ describe("serializeViewerUrlParams", () => {
           { x: 260, opacity: 1.0, color: [0, 255, 180] },
         ],
         ramp: [50, 140],
+        lockPlotToDataRange: true,
+        plotMax: 255,
       },
     ];
     const serialized = serializeViewerUrlParams({ channelSettings: channelStates }, false);

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -382,6 +382,7 @@ describe("Channel state serialization", () => {
         useControlPoints: false,
         controlPoints: [],
         ramp: [0, 255],
+        // TODO: the settings below are not serialized. should they be? (see #384)
         lockPlotToDataRange: true,
         plotMax: 255,
       };


### PR DESCRIPTION
Review time: small (~5-15min)

# Problem

#370 added the ability to modify the range of the transfer function editor's plot. That initial implementation put the state which determines the plot range in the `TfEditor` component itself. This has a significant drawback: that state is destroyed whenever the `TfEditor` component unmounts, including when the channel is disabled, the channel's settings are collapsed, or the user navigates to another tab in the control panel.

# Solution

Lift the relevant state up into the `ChannelState` type, which is held by `ViewerStateProvider` and persists as long as the `App` component is mounted.

This is a little bit of a strange place to put this information, since that type is otherwise reserved for settings which change the appearance of the channel in the viewport. But (I think) it's the least unnatural place for it to go right now.
