### PR TITLE
Styling fixes: warning banner, indeterminate checkboxes

### DIFF
--- a/src/aics-image-viewer/components/ErrorAlert/styles.css
+++ b/src/aics-image-viewer/components/ErrorAlert/styles.css
@@ -17,6 +17,10 @@
 
   .ant-btn-text {
     color: var(--color-text-link);
+
+    &:hover {
+      color: #25affe !important;
+    }
   }
 
   .ant-alert-message div:first-child {

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -349,11 +349,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
   }
 
   .ant-checkbox-inner {
-    background-color: transparent;
-  }
-
-  & .ant-checkbox-indeterminate.checked .ant-checkbox-inner {
-    background-color: var(--color-checkbox-bg);
+    background-color: transparent !important;
   }
 
   // Add outlines to modals and dropdowns


### PR DESCRIPTION
Review time: xsmall

Two minor styling fixes:
Resolves #257: makes link hover color in warning banner a bit less intense
Resolves #343: restores correct styling in indeterminate checkboxes
