### PR TITLE
Update nightly.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Setup Node


### PR DESCRIPTION
ubuntu 20 is deprecated on github actions

Problem
=======
#387

Solution
========
use ubuntu-latest
