### PR TITLE
refactor: Used reload icon instead of undo icon

### DIFF
--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -1,4 +1,4 @@
-import { UndoOutlined } from "@ant-design/icons";
+import { ReloadOutlined } from "@ant-design/icons";
 import { Button, Radio, Select, Tooltip } from "antd";
 import { debounce } from "lodash";
 import React from "react";
@@ -160,7 +160,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
         <div className="viewer-toolbar-left" ref={leftRef}>
           <Tooltip placement="bottom" title="Reset to initial settings" trigger={["focus", "hover"]}>
             <Button className="ant-btn-icon-only btn-borderless" onClick={resetToSavedViewerState}>
-              <UndoOutlined />
+              <ReloadOutlined />
               <span style={visuallyHiddenStyle}>Reset to initial settings</span>
             </Button>
           </Tooltip>


### PR DESCRIPTION
Closes #390, "reset button does not look like a reset action."

Replaces the reload button icon!
![image](https://github.com/user-attachments/assets/e348961f-cf64-443c-a833-9a6ecc6c182b)
