### PR TITLE
Fix view mode and reset camera controls

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -832,6 +832,7 @@ const App: React.FC<AppProps> = (props) => {
     (): [number, number, number] => (image ? image.imageInfo.physicalPixelSize.toArray() : [1, 1, 1]),
     [image?.imageInfo.physicalPixelSize]
   );
+  const resetCamera = useMemo(() => view3d.resetCamera.bind(view3d), [view3d]);
 
   return (
     <StyleProvider>
@@ -880,7 +881,7 @@ const App: React.FC<AppProps> = (props) => {
               hasParentImage={!!props.parentImageUrl}
               hasCellId={!!props.cellId}
               canPathTrace={view3d ? view3d.hasWebGL2() : false}
-              resetCamera={view3d.resetCamera}
+              resetCamera={resetCamera}
               downloadScreenshot={saveScreenshot}
               visibleControls={visibleControls}
             />

--- a/src/aics-image-viewer/components/Toolbar/ViewModeRadioButtons.tsx
+++ b/src/aics-image-viewer/components/Toolbar/ViewModeRadioButtons.tsx
@@ -1,8 +1,9 @@
-import React from "react";
 import { Radio } from "antd";
 import { RadioChangeEvent } from "antd/lib/radio";
+import React from "react";
 
 import { ViewMode } from "../../shared/enums";
+
 const viewModes = [ViewMode.threeD, ViewMode.xy, ViewMode.xz, ViewMode.yz];
 
 interface ViewModeRadioButtonsProps {

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -1,3 +1,4 @@
+import { isEqual } from "lodash";
 import React, { useCallback, useContext, useEffect, useMemo, useReducer, useRef } from "react";
 
 import { getDefaultViewerChannelSettings, getDefaultViewerState } from "../../shared/constants";
@@ -196,12 +197,14 @@ const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState>; chi
   );
 
   // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-  if (props.viewerSettings) {
+  const prevViewerSettingsPropsRef = useRef<Partial<ViewerState> | undefined>(undefined);
+  if (props.viewerSettings && !isEqual(props.viewerSettings, prevViewerSettingsPropsRef.current)) {
     for (const key of Object.keys(props.viewerSettings) as (keyof ViewerState)[]) {
       if (viewerSettings[key] !== props.viewerSettings[key]) {
         changeViewerSetting(key, props.viewerSettings[key] as any);
       }
     }
+    prevViewerSettingsPropsRef.current = props.viewerSettings;
   }
 
   const context = useMemo(() => {


### PR DESCRIPTION
Review time: tiny (~5min)

Fixes two controls which were broken by #391:

- View mode could not be changed. I tracked this to code which synced certain props to viewer state: I broke this code out of a hacky hook in #391, but did a bad job and caused props to be synced to state on _every render_, not just ones on which the props changed.
- Pressing the reset camera button threw an error. This was due to the persistent JS problem of what `this` is - a `bind` call fixed it.
