### PR TITLE
Transfer function range editing v2

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -297,6 +297,7 @@ const App: React.FC<AppProps> = (props) => {
         controlPoints: controlPoints,
         ramp: controlPointsToRamp(ramp),
         // set the default range of the transfer function editor to cover the full range of the data type
+        plotMin: DTYPE_RANGE[thisChannel.dtype].min,
         plotMax: DTYPE_RANGE[thisChannel.dtype].max,
       });
       onResetChannel(channelIndex);

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -86,8 +86,7 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
   );
 
   const createTFEditor = (): React.ReactNode => {
-    const { controlPoints, colorizeEnabled, colorizeAlpha, useControlPoints, ramp, lockPlotToDataRange, plotMax } =
-      channelState;
+    const { controlPoints, colorizeEnabled, colorizeAlpha, useControlPoints, ramp, plotMin, plotMax } = channelState;
     return (
       <TfEditor
         id={"TFEditor" + index}
@@ -100,7 +99,7 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
         colorizeAlpha={colorizeAlpha}
         useControlPoints={useControlPoints}
         ramp={ramp}
-        lockPlotToDataRange={lockPlotToDataRange}
+        plotMin={plotMin}
         plotMax={plotMax}
       />
     );

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/styles.css
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/styles.css
@@ -30,7 +30,11 @@
     display: flex;
     justify-content: start;
     align-items: end;
-    gap: 6px;
+    gap: 5px;
+
+    .ant-btn.ant-btn-sm {
+      padding: 12px 8px;
+    }
   }
 
   &.controls-closed .ant-btn-text:not(:focus-visible) {

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -569,7 +569,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
       {/* ----- MIN/MAX SPINBOXES ----- */}
       {!props.useControlPoints && (
         <div className="tf-editor-control-row ramp-row">
-          Ramp min/max
+          Levels min/max
           <InputNumber
             value={u8ToAbsolute(props.ramp[0], props.channelData)}
             onChange={(v) => v !== null && setRamp([absoluteToU8(v, props.channelData), props.ramp[1]])}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -664,13 +664,13 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
 
       {/* ----- PLOT RANGE ----- */}
       <div className="tf-editor-control-row plot-range-row">
-        Plot min/max{" "}
+        Plot min/max
         <InputNumber
           value={props.plotMin}
           onChange={(v) => v !== null && changeChannelSetting({ plotMin: v, plotMax: Math.max(v + 1, props.plotMax) })}
           formatter={numberFormatter}
           min={typeRange.min}
-          max={typeRange.max}
+          max={typeRange.max - 1}
           size="small"
           controls={false}
         />
@@ -678,7 +678,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
           value={props.plotMax}
           onChange={(v) => v !== null && changeChannelSetting({ plotMax: v, plotMin: Math.min(v - 1, props.plotMin) })}
           formatter={numberFormatter}
-          min={typeRange.min}
+          min={typeRange.min + 1}
           max={typeRange.max}
           size="small"
           controls={false}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -664,18 +664,25 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
 
       {/* ----- PLOT RANGE ----- */}
       <div className="tf-editor-control-row plot-range-row">
-        <span>
-          Plot max{" "}
-          <InputNumber
-            value={props.plotMax}
-            onChange={(v) => v !== null && changeChannelSetting({ plotMax: v })}
-            formatter={numberFormatter}
-            min={typeRange.min}
-            max={typeRange.max}
-            size="small"
-            controls={false}
-          />
-        </span>
+        Plot min/max{" "}
+        <InputNumber
+          value={props.plotMin}
+          onChange={(v) => v !== null && changeChannelSetting({ plotMin: v, plotMax: Math.max(v + 1, props.plotMax) })}
+          formatter={numberFormatter}
+          min={typeRange.min}
+          max={typeRange.max}
+          size="small"
+          controls={false}
+        />
+        <InputNumber
+          value={props.plotMax}
+          onChange={(v) => v !== null && changeChannelSetting({ plotMax: v, plotMin: Math.min(v - 1, props.plotMin) })}
+          formatter={numberFormatter}
+          min={typeRange.min}
+          max={typeRange.max}
+          size="small"
+          controls={false}
+        />
       </div>
 
       {/* ----- COLORIZE SLIDER ----- */}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -542,7 +542,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
           />
         ))
     : null;
-  // move selected control point to the end so it's not occluded by other nearby points
+  // move selected control point to the end so it's drawn last and not occluded by other nearby points
   if (controlPointCircles !== null && selectedPointIdx !== null) {
     controlPointCircles.push(controlPointCircles.splice(selectedPointIdx, 1)[0]);
   }
@@ -683,6 +683,9 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
           size="small"
           controls={false}
         />
+        <Button size="small" onClick={() => changeChannelSetting({ plotMin: typeRange.min, plotMax: typeRange.max })}>
+          Full range
+        </Button>
       </div>
 
       {/* ----- COLORIZE SLIDER ----- */}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -62,7 +62,7 @@ type TfEditorProps = {
   useControlPoints: boolean;
   controlPoints: ControlPoint[];
   ramp: [number, number];
-  lockPlotToDataRange: boolean;
+  plotMin: number;
   plotMax: number;
 };
 
@@ -266,12 +266,12 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   // d3 scales define the mapping between data and screen space (and do the heavy lifting of generating plot axes)
   /** `xScale` is in raw intensity range, not U8 range. We use `u8ToAbsolute` and `absoluteToU8` to translate to U8. */
   const [xScale, plotMinU8, plotMaxU8] = useMemo(() => {
-    const domain = props.lockPlotToDataRange ? [rawMin, rawMax] : [typeRange.min, props.plotMax];
+    const domain = [props.plotMin, props.plotMax];
     const scale = d3.scaleLinear().domain(domain).range([0, innerWidth]);
     const plotMinU8 = absoluteToU8(domain[0], props.channelData);
     const plotMaxU8 = absoluteToU8(domain[1], props.channelData);
     return [scale, plotMinU8, plotMaxU8];
-  }, [innerWidth, rawMin, rawMax, typeRange, props.lockPlotToDataRange, props.plotMax, props.channelData]);
+  }, [innerWidth, props.plotMin, props.plotMax, props.channelData]);
   const yScale = useMemo(() => d3.scaleLinear().domain([0, 1]).range([innerHeight, 0]), [innerHeight]);
 
   const mouseEventToControlPointValues = (event: MouseEvent | React.MouseEvent): [number, number] => {
@@ -665,27 +665,17 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
       {/* ----- PLOT RANGE ----- */}
       <div className="tf-editor-control-row plot-range-row">
         <span>
-          <Checkbox
-            checked={props.lockPlotToDataRange}
-            onChange={(e) => changeChannelSetting({ lockPlotToDataRange: e.target.checked })}
-          >
-            Lock to data range
-          </Checkbox>
+          Plot max{" "}
+          <InputNumber
+            value={props.plotMax}
+            onChange={(v) => v !== null && changeChannelSetting({ plotMax: v })}
+            formatter={numberFormatter}
+            min={typeRange.min}
+            max={typeRange.max}
+            size="small"
+            controls={false}
+          />
         </span>
-        {!props.lockPlotToDataRange && (
-          <span>
-            Plot max{" "}
-            <InputNumber
-              value={props.plotMax}
-              onChange={(v) => v !== null && changeChannelSetting({ plotMax: v })}
-              formatter={numberFormatter}
-              min={typeRange.min}
-              max={typeRange.max}
-              size="small"
-              controls={false}
-            />
-          </span>
-        )}
       </div>
 
       {/* ----- COLORIZE SLIDER ----- */}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -552,7 +552,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   return (
     <div>
       {/* ----- PRESET BUTTONS ----- */}
-      <div className="tf-editor-control-row button-row">
+      <div className="button-row">
         {createTFGeneratorButton("resetXF", "None", "Reset transfer function to full range.")}
         {createTFGeneratorButton("auto98XF", "Default", "Ramp from 50th percentile to 98th.")}
         {createTFGeneratorButton("auto2XF", "IJ Auto", `Emulates ImageJ's "auto" button.`)}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -114,7 +114,7 @@ function u8ToAbsolute(value: number, channel: { rawMin: number; rawMax: number }
   return channel.rawMin + (value / 255) * (channel.rawMax - channel.rawMin);
 }
 
-function absoluteToU8(value: number, channel: Channel): number {
+function absoluteToU8(value: number, channel: { rawMin: number; rawMax: number }): number {
   return ((value - channel.rawMin) / (channel.rawMax - channel.rawMin)) * 255;
 }
 
@@ -268,10 +268,11 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   const [xScale, plotMinU8, plotMaxU8] = useMemo(() => {
     const domain = [props.plotMin, props.plotMax];
     const scale = d3.scaleLinear().domain(domain).range([0, innerWidth]);
-    const plotMinU8 = absoluteToU8(domain[0], props.channelData);
-    const plotMaxU8 = absoluteToU8(domain[1], props.channelData);
+    const channelRange = { rawMin, rawMax };
+    const plotMinU8 = absoluteToU8(props.plotMin, channelRange);
+    const plotMaxU8 = absoluteToU8(props.plotMax, channelRange);
     return [scale, plotMinU8, plotMaxU8];
-  }, [innerWidth, props.plotMin, props.plotMax, props.channelData]);
+  }, [innerWidth, props.plotMin, props.plotMax, rawMin, rawMax]);
   const yScale = useMemo(() => d3.scaleLinear().domain([0, 1]).range([innerHeight, 0]), [innerHeight]);
 
   const mouseEventToControlPointValues = (event: MouseEvent | React.MouseEvent): [number, number] => {
@@ -683,6 +684,9 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
           size="small"
           controls={false}
         />
+        <Button size="small" onClick={() => changeChannelSetting({ plotMin: rawMin, plotMax: rawMax })}>
+          Fit to data
+        </Button>
         <Button size="small" onClick={() => changeChannelSetting({ plotMin: typeRange.min, plotMax: typeRange.max })}>
           Full range
         </Button>

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -552,10 +552,10 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
     <div>
       {/* ----- PRESET BUTTONS ----- */}
       <div className="button-row">
-        {createTFGeneratorButton("resetXF", "None", "Reset transfer function to full range.")}
-        {createTFGeneratorButton("auto98XF", "Default", "Ramp from 50th percentile to 98th.")}
-        {createTFGeneratorButton("auto2XF", "IJ Auto", `Emulates ImageJ's "auto" button.`)}
-        {createTFGeneratorButton("bestFitXF", "Auto 2", "Ramp over the middle 80% of data.")}
+        {createTFGeneratorButton("auto98XF", "Default", "Ramp from 50th percentile to 98th")}
+        {createTFGeneratorButton("auto2XF", "IJ Auto", `Emulates ImageJ's "auto" button`)}
+        {createTFGeneratorButton("resetXF", "Auto 1", "Ramp over the full data range (0% to 100%)")}
+        {createTFGeneratorButton("bestFitXF", "Auto 2", "Ramp over the middle 80% of data")}
         <Checkbox
           checked={props.useControlPoints}
           onChange={(e) => changeChannelSetting({ useControlPoints: e.target.checked })}

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -682,7 +682,11 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
           size="small"
           controls={false}
         />
-        <Button size="small" onClick={() => changeChannelSetting({ plotMin: rawMin, plotMax: rawMax })}>
+        <Button
+          size="small"
+          style={{ marginLeft: "12px" }}
+          onClick={() => changeChannelSetting({ plotMin: rawMin, plotMax: rawMax })}
+        >
           Fit to data
         </Button>
         <Button size="small" onClick={() => changeChannelSetting({ plotMin: typeRange.min, plotMax: typeRange.max })}>

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -519,7 +519,9 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
 
   const createTFGeneratorButton = (generator: string, name: string, description: string): React.ReactNode => (
     <Tooltip title={description} placement="top">
-      <Button onClick={() => applyTFGenerator(generator)}>{name}</Button>
+      <Button size="small" onClick={() => applyTFGenerator(generator)}>
+        {name}
+      </Button>
     </Tooltip>
   );
 
@@ -550,7 +552,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   return (
     <div>
       {/* ----- PRESET BUTTONS ----- */}
-      <div className="button-row">
+      <div className="tf-editor-control-row button-row">
         {createTFGeneratorButton("resetXF", "None", "Reset transfer function to full range.")}
         {createTFGeneratorButton("auto98XF", "Default", "Ramp from 50th percentile to 98th.")}
         {createTFGeneratorButton("auto2XF", "IJ Auto", `Emulates ImageJ's "auto" button.`)}

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -49,6 +49,10 @@
         text-align: right;
       }
     }
+
+    .ant-btn.ant-btn-sm {
+      padding: 12px 8px;
+    }
   }
 
   .tick text {

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -30,9 +30,9 @@
     color: var(--color-controlpanel-text);
     align-items: center;
     min-height: 24px;
+    gap: 5px;
 
     &.ramp-row {
-      gap: 6px;
       margin-top: 15px;
     }
 
@@ -48,10 +48,6 @@
       input {
         text-align: right;
       }
-    }
-
-    .ant-btn.ant-btn-sm {
-      padding: 12px 8px;
     }
   }
 

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -37,7 +37,6 @@
     }
 
     &.plot-range-row {
-      justify-content: space-between;
       margin-bottom: 20px;
     }
 

--- a/src/aics-image-viewer/components/TfEditor/styles.css
+++ b/src/aics-image-viewer/components/TfEditor/styles.css
@@ -42,7 +42,7 @@
 
     .ant-input-number {
       border-color: var(--color-button-tertiary-outline);
-      width: 72px;
+      width: 64px;
 
       input {
         text-align: right;

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -70,7 +70,7 @@ export interface ChannelState {
   ramp: [number, number];
   useControlPoints: boolean;
   controlPoints: ControlPoint[];
-  lockPlotToDataRange: boolean;
+  plotMin: number;
   plotMax: number;
 }
 

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -213,7 +213,7 @@ export const getDefaultChannelState = (index: number = 0): ChannelState => {
       { x: 0, opacity: 0, color: [255, 255, 255] },
       { x: 255, opacity: 1, color: [255, 255, 255] },
     ],
-    lockPlotToDataRange: true,
+    plotMin: 0,
     plotMax: TFEDITOR_MAX_BIN,
   };
 };

--- a/src/aics-image-viewer/shared/utils/viewerState.ts
+++ b/src/aics-image-viewer/shared/utils/viewerState.ts
@@ -82,7 +82,7 @@ export function initializeOneChannelSetting(
     useControlPoints: initSettings.controlPointsEnabled ?? defaultChannelState.useControlPoints,
     controlPoints: initSettings.controlPoints ?? defaultChannelState.controlPoints,
     ramp: initSettings.ramp ?? defaultChannelState.ramp,
-    lockPlotToDataRange: defaultChannelState.lockPlotToDataRange,
+    plotMin: defaultChannelState.plotMin,
     plotMax: defaultChannelState.plotMax,
   };
 }

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -246,7 +246,7 @@ describe("Channel state serialization", () => {
       { x: 255, opacity: 1.0, color: [255, 255, 255] },
     ],
     ramp: [0, 255],
-    lockPlotToDataRange: true,
+    plotMin: 0,
     plotMax: 255,
   };
   const DEFAULT_SERIALIZED_CHANNEL_STATE: ViewerChannelSettingParams = {
@@ -383,7 +383,7 @@ describe("Channel state serialization", () => {
         controlPoints: [],
         ramp: [0, 255],
         // TODO: the settings below are not serialized. should they be? (see #384)
-        lockPlotToDataRange: true,
+        plotMin: 0,
         plotMax: 255,
       };
       const serializedCustomChannelState: Required<Omit<ViewerChannelSettingParams, "lut">> = {
@@ -832,7 +832,7 @@ describe("serializeViewerUrlParams", () => {
           { x: 1, opacity: 1, color: [255, 0, 0] },
         ],
         ramp: [-10, 260.1],
-        lockPlotToDataRange: true,
+        plotMin: 0,
         plotMax: 255,
       },
       {
@@ -854,7 +854,7 @@ describe("serializeViewerUrlParams", () => {
           { x: 260, opacity: 1.0, color: [0, 255, 180] },
         ],
         ramp: [50, 140],
-        lockPlotToDataRange: true,
+        plotMin: 0,
         plotMax: 255,
       },
     ];


### PR DESCRIPTION
Review time: small (~5-15min)

Resolves #395: implements @lynwilhelm's design for better transfer function editor range controls from #374.

In the first version of range controls (implemented in #370) the user can either "lock to data range" or freely adjust only the maximum of the plot's domain. In this version, users always have full control over both the min and max, and we're never "locked" to any range. Instead, the user can use new push buttons "Fit to data" and "Full range" to apply the default ranges from the previous "locked" and "unlocked" states once.

Also, buttons are more compact, and the language of a preset transfer function button is changed a bit.

| Before | After |
| ------- | ------- |
| ![image](https://github.com/user-attachments/assets/4cb3cdd8-e0e6-4bac-b359-f8c7765b4b55) | ![image](https://github.com/user-attachments/assets/46eed379-8419-4b5f-ae75-329f3f000786) |
