### PR TITLE
Fix/single slice slider range

### DIFF
--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -81,7 +81,7 @@ const SliderRow: React.FC<SliderRowProps> = ({
           />
         </span>
       )}
-      {max > 0 && (
+      {max > min && (
         <span className="slider-values">
           <NumericInput
             min={min}

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -51,7 +51,7 @@ const SliderRow: React.FC<SliderRowProps> = ({
   return (
     <span className="axis-slider-container">
       <span className="slider-name">{label}</span>
-      {max === 0 ? (
+      {max === min ? (
         <i>No values to adjust</i>
       ) : (
         <span className="axis-slider">


### PR DESCRIPTION
Review time: xsmall 2min

Single-slice images currently cause nouislider to error out, saying "the min and max cannot be the same."

#383 changed the way clipping sliders are indexed, but missed updating the guard for whether there was any range to adjust in the first place. This fixes the guard.