### PR TITLE
Update vole-core to 3.15.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.13.1",
       "license": "ISC",
       "dependencies": {
-        "@aics/vole-core": "^3.15.2",
+        "@aics/vole-core": "^3.15.7",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@aics/vole-core": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.15.2.tgz",
-      "integrity": "sha512-8u6su69El8fB/AC5p+oNFddRLv/bYZDwkMt0zPBh9lm5ztrX01PY81dzFGEqsuKZBD4MMcCZjId7mNOI7PHWOQ==",
+      "version": "3.15.7",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.15.7.tgz",
+      "integrity": "sha512-AoilYcq2vIaD0zgMNJHAhe8XvjWoKWS9myTW+pIghOoELSfIT0cS32BuRgeNY4rOpbKW/NeWo62JMbIO7rEGwQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/vole-core": "^3.15.2",
+    "@aics/vole-core": "^3.15.7",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",


### PR DESCRIPTION
This is a patch version upgrade (from 3.15.2). I need this to pick up import resolution fixes in vole-core; my branch upgrading CFE to the latest version doesn't build without it.
