### PR TITLE
add test data only for dev build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.13.1",
       "license": "ISC",
       "dependencies": {
-        "@aics/vole-core": "^3.15.2",
+        "@aics/vole-core": "^3.15.7",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@aics/vole-core": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.15.2.tgz",
-      "integrity": "sha512-8u6su69El8fB/AC5p+oNFddRLv/bYZDwkMt0zPBh9lm5ztrX01PY81dzFGEqsuKZBD4MMcCZjId7mNOI7PHWOQ==",
+      "version": "3.15.7",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.15.7.tgz",
+      "integrity": "sha512-AoilYcq2vIaD0zgMNJHAhe8XvjWoKWS9myTW+pIghOoELSfIT0cS32BuRgeNY4rOpbKW/NeWo62JMbIO7rEGwQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/vole-core": "^3.15.2",
+    "@aics/vole-core": "^3.15.7",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -10,6 +10,7 @@ import { BannerVideo } from "../../assets/videos";
 import type { AppDataProps, DatasetEntry, ProjectEntry } from "../../types";
 import { encodeImageUrlProp, parseViewerUrlParams } from "../../utils/url_utils";
 import { landingPageContent } from "./content";
+import { testDataContent } from "./testData";
 import { FlexColumn, FlexColumnAlignCenter, FlexRowAlignCenter, VisuallyHidden } from "./utils";
 
 import Header from "../Header";
@@ -404,7 +405,9 @@ export default function LandingPage(): ReactElement {
       </LoadPromptContainer>
 
       <ContentContainer style={{ paddingBottom: "400px" }}>
-        <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
+        <ProjectList>{
+         (VOLEAPP_BUILD_ENVIRONMENT === "dev") ? [...landingPageContent, ...testDataContent].map(renderProject) : landingPageContent.map(renderProject)
+        }</ProjectList>
       </ContentContainer>
 
       <ContentContainer style={{ padding: "0 30px 40px 30px" }}>

--- a/website/components/LandingPage/testData.ts
+++ b/website/components/LandingPage/testData.ts
@@ -1,0 +1,348 @@
+import { RawArrayInfo, RawArrayLoaderOptions, VolumeMaker } from "@aics/vole-core";
+
+import { ViewMode } from "../../../src";
+import { AppDataProps, ProjectEntry } from "../../types";
+
+function concatenateArrays(arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((acc, arr) => acc + arr.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}
+
+function createTestVolume(dtype: string): RawArrayLoaderOptions {
+  const sizeX = 64;
+  const sizeY = 64;
+  const sizeZ = 64;
+  const imgData: RawArrayInfo = {
+    name: "AICS-10_5_5",
+    sizeX,
+    sizeY,
+    sizeZ,
+    sizeC: 3,
+    physicalPixelSize: [1, 1, 1],
+    spatialUnit: "",
+    channelNames: ["DRAQ5", "EGFP", "SEG_Memb"],
+  };
+
+  // generate some raw volume data
+  const channelVolumes = [
+    VolumeMaker.createSphere(sizeX, sizeY, sizeZ, 24, dtype),
+    VolumeMaker.createTorus(sizeX, sizeY, sizeZ, 24, 8, dtype),
+    VolumeMaker.createCone(sizeX, sizeY, sizeZ, 24, 24, dtype),
+  ];
+  const alldata = concatenateArrays(channelVolumes);
+  return {
+    metadata: imgData,
+    data: {
+      dtype: dtype,
+      // [c,z,y,x]
+      shape: [channelVolumes.length, sizeZ, sizeY, sizeX],
+      // the bits (assumed uint8!!)
+      buffer: new DataView(alldata.buffer),
+    },
+  };
+}
+const v0 = createTestVolume("uint8");
+const v1 = createTestVolume("uint16");
+const v2 = createTestVolume("float32");
+
+const testDataBaseViewerSettings: Partial<AppDataProps> = {
+  viewerChannelSettings: {
+    maskChannelName: "",
+    groups: [
+      {
+        name: "Channels",
+        channels: [
+          { match: [0], enabled: true, lut: ["autoij", "autoij"] },
+          { match: [1], enabled: true, lut: ["autoij", "autoij"] },
+          { match: [2], enabled: true, lut: ["autoij", "autoij"] },
+        ],
+      },
+    ],
+  },
+  viewerSettings: {
+    viewMode: ViewMode.threeD,
+    density: 2.5,
+  },
+};
+
+export const testDataContent: ProjectEntry[] = [
+  {
+    name: "Developer test data",
+    inReview: false,
+    description: "Various test data for dev only.",
+    datasets: [
+      {
+        name: "procedural uint8",
+        loadParams: {
+          imageUrl: "",
+          rawData: v0.data,
+          rawDims: v0.metadata,
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "procedural uint16",
+        loadParams: {
+          imageUrl: "",
+          rawData: v1.data,
+          rawDims: v1.metadata,
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "procedural float32",
+        loadParams: {
+          imageUrl: "",
+          rawData: v2.data,
+          rawDims: v2.metadata,
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "CellPainting",
+        loadParams: {
+          imageUrl: {
+            scenes: [
+              [
+                "https://cellpainting-gallery.s3.us-east-1.amazonaws.com/cpg0000-jump-pilot/source_4/images/2020_12_08_CPJUMP1_Bleaching/images/BR00116992E__2020-11-12T01_22_40-Measurement1/Images/r01c01f01p01-ch1sk5fk1fl1.tiff",
+                "https://cellpainting-gallery.s3.us-east-1.amazonaws.com/cpg0000-jump-pilot/source_4/images/2020_12_08_CPJUMP1_Bleaching/images/BR00116992E__2020-11-12T01_22_40-Measurement1/Images/r01c01f01p01-ch2sk5fk1fl1.tiff",
+                "https://cellpainting-gallery.s3.us-east-1.amazonaws.com/cpg0000-jump-pilot/source_4/images/2020_12_08_CPJUMP1_Bleaching/images/BR00116992E__2020-11-12T01_22_40-Measurement1/Images/r01c01f01p01-ch3sk5fk1fl1.tiff",
+                "https://cellpainting-gallery.s3.us-east-1.amazonaws.com/cpg0000-jump-pilot/source_4/images/2020_12_08_CPJUMP1_Bleaching/images/BR00116992E__2020-11-12T01_22_40-Measurement1/Images/r01c01f01p01-ch4sk5fk1fl1.tiff",
+                "https://cellpainting-gallery.s3.us-east-1.amazonaws.com/cpg0000-jump-pilot/source_4/images/2020_12_08_CPJUMP1_Bleaching/images/BR00116992E__2020-11-12T01_22_40-Measurement1/Images/r01c01f01p01-ch5sk5fk1fl1.tiff",
+                "https://cellpainting-gallery.s3.us-east-1.amazonaws.com/cpg0000-jump-pilot/source_4/images/2020_12_08_CPJUMP1_Bleaching/images/BR00116992E__2020-11-12T01_22_40-Measurement1/Images/r01c01f01p01-ch6sk5fk1fl1.tiff",
+                "https://cellpainting-gallery.s3.us-east-1.amazonaws.com/cpg0000-jump-pilot/source_4/images/2020_12_08_CPJUMP1_Bleaching/images/BR00116992E__2020-11-12T01_22_40-Measurement1/Images/r01c01f01p01-ch7sk5fk1fl1.tiff",
+                "https://cellpainting-gallery.s3.us-east-1.amazonaws.com/cpg0000-jump-pilot/source_4/images/2020_12_08_CPJUMP1_Bleaching/images/BR00116992E__2020-11-12T01_22_40-Measurement1/Images/r01c01f01p01-ch8sk5fk1fl1.tiff",
+              ],
+            ],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Test pick",
+        loadParams: {
+          imageUrl: {
+            scenes: [
+              [
+                "https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/seg.ome.zarr",
+              ],
+            ],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "OME TIFF variance",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://animatedcell-test-data.s3.us-west-2.amazonaws.com/AICS-12_881.ome.tif"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+
+      {
+        name: "Time series mitosis zarr",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://animatedcell-test-data.s3.us-west-2.amazonaws.com/timelapse/timeseries_mitosis.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+
+      {
+        name: "Zarr EMT (internal)",
+        loadParams: {
+          imageUrl: {
+            scenes: [
+              [
+                "https://dev-aics-dtp-001.int.allencell.org/users/danielt/3500005818_20230811__20x_Timelapse-02(P27-E7).ome.zarr",
+              ],
+            ],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+
+      {
+        name: "Zarr IDR 1",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0076A/10501752.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Zarr IDR 2",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025553.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Zarr Variance 2-scene",
+        loadParams: {
+          imageUrl: {
+            scenes: [
+              ["https://animatedcell-test-data.s3.us-west-2.amazonaws.com/variance/1.zarr"],
+              ["https://animatedcell-test-data.s3.us-west-2.amazonaws.com/variance/2.zarr"],
+            ],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Zarr Nucmorph 0",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://animatedcell-test-data.s3.us-west-2.amazonaws.com/20200323_F01_001/P13-C4.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Zarr Nucmorph 1",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://animatedcell-test-data.s3.us-west-2.amazonaws.com/20200323_F01_001/P15-C3.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Zarr Nucmorph 2",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://animatedcell-test-data.s3.us-west-2.amazonaws.com/20200323_F01_001/P7-B4.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Zarr Nucmorph 3",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://animatedcell-test-data.s3.us-west-2.amazonaws.com/20200323_F01_001/P8-B4.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Zarr fly brain",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846152.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "Zarr UK",
+        loadParams: {
+          imageUrl: {
+            scenes: [["https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr"]],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "CFE Json",
+        loadParams: {
+          imageUrl: {
+            scenes: [
+              [
+                "https://s3-us-west-2.amazonaws.com/bisque.allencell.org/v2.0.0/Cell-Viewer_Thumbnails/AICS-61/AICS-61_139803_atlas.json",
+              ],
+            ],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+      {
+        name: "ABM tiff",
+        loadParams: {
+          imageUrl: {
+            scenes: [
+              [
+                "https://animatedcell-test-data.s3.us-west-2.amazonaws.com/HAMILTONIAN_TERM_FOV_VSAHJUP_0000_000192.ome.tif",
+              ],
+            ],
+          },
+          cellId: "",
+          imageDownloadHref: "",
+          parentImageDownloadHref: "",
+          ...testDataBaseViewerSettings,
+        },
+      },
+    ],
+  },
+];
+
+//   procedural: { type: VolumeFileFormat.DATA, url: "", dtype: "uint8" },
+//   procedural2: { type: VolumeFileFormat.DATA, url: "", dtype: "uint16" },
+//   procedural3: { type: VolumeFileFormat.DATA, url: "", dtype: "float32" },
+// };


### PR DESCRIPTION
Problem
=======
A range of test data would be nice to have for testing vole-app, similar to what is in vole-core.

Solution
========
Add test urls copied from vole-core.  Render in landing page only in dev builds.

Not yet working with new RawArray datatype enhancements in vole-core.

## Type of change

* New feature (non-breaking change which adds functionality)

