### PR TITLE
feat: Raw data values in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The volume shader itself is a heavily modified version of one that has distant o
 ## to use
 
 - `https://vole.allencell.org/?url=path/to/ZARR`
-- for more url parameters, see [`URL_SPEC.md`](documentation\URL_SPEC.md)
+- for more url parameters, see [`URL_SPEC.md`](documentation/URL_SPEC.md)
 
 or as React component:
 

--- a/documentation/URL_SPEC.md
+++ b/documentation/URL_SPEC.md
@@ -156,11 +156,11 @@ following:
 
 Examples:
 
-| `lut` value | Description                                                                   |
-| ----------- | ----------------------------------------------------------------------------- |
-| `0:255`     | Linear mapping from bin 0 to bin 255.                                         |
-| `0:v200`    | Linear mapping from bin 0 (minimum intensity value) to the raw intensity 200. |
-| `0:p90`     | Linear mapping from bin 0 to the 90th percentile.                             |
-| `p10:p95`   | Linear mapping from the 10th percentile to the 95th.                          |
-| `m100:m150` | Linear mapping from the median to 1.5 times the median.                       |
-| `autoij:0`  | Uses the "auto" algorithm from ImageJ.                                        |
+| `lut` value | Description                                                |
+| ----------- | ---------------------------------------------------------- |
+| `0:255`     | Linear mapping from bin 0 to bin 255.                      |
+| `v10:v200`  | Linear mapping from raw intensity 10 to raw intensity 200. |
+| `0:p90`     | Linear mapping from bin 0 to the 90th percentile.          |
+| `p10:p95`   | Linear mapping from the 10th percentile to the 95th.       |
+| `m100:m150` | Linear mapping from the median to 1.5 times the median.    |
+| `autoij:0`  | Uses the "auto" algorithm from ImageJ.                     |

--- a/documentation/URL_SPEC.md
+++ b/documentation/URL_SPEC.md
@@ -146,6 +146,7 @@ linearly from an opacity of `0` to `1`. The `min` and `max` can match any of the
 following:
 
 - Plain numbers are treated as bin indices, in a `[0, 255]` range.
+- `v{n}` represents an image intensity value, where `n` is an integer.
 - `p{n}` represents a percentile, where `n` is a percentile in the `[0, 100]` range.
 - `m{n}` represents the volume's median intensity multiplied by `n / 100`.
 - `autoij` in either the min or max fields will approximate the ["auto"
@@ -155,10 +156,11 @@ following:
 
 Examples:
 
-| `lut` value | Description                                                 |
-| ----------- | ----------------------------------------------------------- |
-| `0:255`     | Linear mapping from intensity bin 0 to intensity bin 255.   |
-| `0:p90`     | Linear mapping from intensity bin 0 to the 90th percentile. |
-| `p10:p95`   | Linear mapping from the 10th percentile to the 95th.        |
-| `m100:m150` | Linear mapping from the median to 1.5 times the median.     |
-| `autoij:0`  | Uses the "auto" algorithm from ImageJ.                      |
+| `lut` value | Description                                                                   |
+| ----------- | ----------------------------------------------------------------------------- |
+| `0:255`     | Linear mapping from bin 0 to bin 255.                                         |
+| `0:v200`    | Linear mapping from bin 0 (minimum intensity value) to the raw intensity 200. |
+| `0:p90`     | Linear mapping from bin 0 to the 90th percentile.                             |
+| `p10:p95`   | Linear mapping from the 10th percentile to the 95th.                          |
+| `m100:m150` | Linear mapping from the median to 1.5 times the median.                       |
+| `autoij:0`  | Uses the "auto" algorithm from ImageJ.                                        |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.13.2",
       "license": "ISC",
       "dependencies": {
-        "@aics/vole-core": "^3.15.7",
+        "@aics/vole-core": "^4.0.0",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@aics/vole-core": {
-      "version": "3.15.7",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-3.15.7.tgz",
-      "integrity": "sha512-AoilYcq2vIaD0zgMNJHAhe8XvjWoKWS9myTW+pIghOoELSfIT0cS32BuRgeNY4rOpbKW/NeWo62JMbIO7rEGwQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.0.0.tgz",
+      "integrity": "sha512-pxGb/2JpP4Z4D3mU43bflVc6p42RxLetQ8offaX1MeTANbfskrj2Q4rJ5HxY6/iZ8Y5fbCB6sESjcxS8Gi6skw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
@@ -3452,9 +3452,9 @@
       }
     },
     "node_modules/@petamoriken/float16": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.0.tgz",
-      "integrity": "sha512-rYUZ+VFjPHD0NT2JYKj64NxXxrV642IiyaUxxorTEj0S3hT7B5Ixezyc9Fn+XvSk0ETEBp5VWjGIErzh0ug0Xw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
       "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5435,9 +5435,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zarrita/storage": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.1.tgz",
-      "integrity": "sha512-6/NUCvpzsIxfxeMv59jRTl/bOZg3GZfMP6iR8EIqrTaaE0S2jLL/ceX1OxcFBKnuA8/Z2YmgX4SFBHwFGrCcsw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.2.tgz",
+      "integrity": "sha512-zUi3CqeEU6avbE104qm5y4MGZbyxmqxXBIh3jyAJgQ4eQRG7KJ6cCmoD7wS7y/uCTl6nUiG7QU6k8QbyfrFjyg==",
       "license": "MIT",
       "dependencies": {
         "reference-spec-reader": "^0.2.0",
@@ -14891,9 +14891,9 @@
       }
     },
     "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
       "license": "MIT"
     },
     "node_modules/parse-json": {
@@ -20317,9 +20317,9 @@
       }
     },
     "node_modules/web-worker": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
-      "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
@@ -20992,9 +20992,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/xml-utils": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.1.tgz",
-      "integrity": "sha512-Dn6vJ1Z9v1tepSjvnCpwk5QqwIPcEFKdgnjqfYOABv1ngSofuAhtlugcUC3ehS1OHdgDWSG6C5mvj+Qm15udTQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
       "license": "CC0-1.0"
     },
     "node_modules/xmlchars": {
@@ -21097,12 +21097,12 @@
       }
     },
     "node_modules/zarrita": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.1.tgz",
-      "integrity": "sha512-cyujP70BOl5DiXuLtM+0j9nq/pAov4SKXRYIQQOVnk2TfBg/jopX+FXLbqkq3ULOxFLB5AwkPbSp5KvZXoJrbQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.3.tgz",
+      "integrity": "sha512-to2JRq9nHwYdhWEwJwytHYdMYC6I0f2vKUAQfYkgrwwy8OjShhwmv4sH9drzyV3sLzdy7XS9N1ipdMA/Qjspow==",
       "license": "MIT",
       "dependencies": {
-        "@zarrita/storage": "^0.1.1",
+        "@zarrita/storage": "^0.1.2",
         "numcodecs": "^0.3.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aics/vole-app",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aics/vole-app",
-      "version": "2.13.1",
+      "version": "2.13.2",
       "license": "ISC",
       "dependencies": {
         "@aics/vole-core": "^3.15.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/vole-core": "^3.15.7",
+    "@aics/vole-core": "^4.0.0",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aics/vole-app",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "web view of cell volume images",
   "repository": "github:allen-cell-animated/vole-app",
   "main": "es/index.js",

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -260,8 +260,8 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
 
   const svgRef = useRef<SVGSVGElement>(null); // need access to SVG element to measure mouse position
 
-  const { rawMin, rawMax, dtype, histogram } = props.channelData;
-  const typeRange = DTYPE_RANGE[dtype];
+  const { histogram } = props.channelData;
+  const typeRange = DTYPE_RANGE[props.channelData.dtype];
 
   // d3 scales define the mapping between data and screen space (and do the heavy lifting of generating plot axes)
   /** `xScale` is in raw intensity range, not U8 range. We use `u8ToAbsolute` and `absoluteToU8` to translate to U8. */
@@ -682,7 +682,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
         <Button
           size="small"
           style={{ marginLeft: "12px" }}
-          onClick={() => changeChannelSetting({ plotMin: rawMin, plotMax: rawMax })}
+          onClick={() => changeChannelSetting({ plotMin: props.channelData.rawMin, plotMax: props.channelData.rawMax })}
         >
           Fit to data
         </Button>

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -269,8 +269,8 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
     () => d3.scaleLinear().domain([plotMin, plotMax]).range([0, innerWidth]),
     [innerWidth, plotMin, plotMax]
   );
-  const plotMinU8 = useMemo(() => absoluteToBin(plotMin, histogram), [plotMin, rawMin, rawMax]);
-  const plotMaxU8 = useMemo(() => absoluteToBin(plotMax, histogram), [plotMax, rawMin, rawMax]);
+  const plotMinU8 = useMemo(() => absoluteToBin(plotMin, histogram), [plotMin, histogram]);
+  const plotMaxU8 = useMemo(() => absoluteToBin(plotMax, histogram), [plotMax, histogram]);
   const yScale = useMemo(() => d3.scaleLinear().domain([0, 1]).range([innerHeight, 0]), [innerHeight]);
 
   const mouseEventToControlPointValues = (event: MouseEvent | React.MouseEvent): [number, number] => {
@@ -423,7 +423,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
       .y1(innerHeight)
       .curve(d3.curveLinear);
     return areaGenerator(controlPointsToRender) ?? undefined;
-  }, [controlPointsToRender, xScale, yScale, innerHeight, rawMin, rawMax]);
+  }, [controlPointsToRender, xScale, yScale, innerHeight, histogram]);
 
   /** d3-generated svg data string representing the "basic mode" min/max slider handles */
   const sliderHandlePath = useMemo(() => d3.symbol().type(sliderHandleSymbol).size(80)() ?? undefined, []);
@@ -496,7 +496,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
         .attr("y", (len) => binScale(len))
         .attr("height", (len) => innerHeight - binScale(len));
     },
-    [xScale, rawMin, rawMax, histogram, innerWidth, innerHeight, plotMinU8, plotMaxU8]
+    [xScale, histogram, innerWidth, innerHeight, plotMinU8, plotMaxU8]
   );
 
   const applyTFGenerator = useCallback(

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -33,7 +33,7 @@ function parseLutValue(value: string, histogram: Histogram): number {
     return histogram.findBinOfPercentile(parsedValue);
   } else if (firstChar === "v") {
     const parsedValue = parseFloat(value.substring(1));
-    return histogram.findBinOfValue(parsedValue);
+    return histogram.findFractionalBinOfValue(parsedValue);
   } else {
     // plain number
     return parseFloat(value);

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -41,18 +41,21 @@ function parseLutValue(value: string, histogram: Histogram): number {
 }
 
 /**
- * Parses a lookup table (LUT) from a `ViewerChannelSetting` object, where the `lut` field is an
- * array of two alphanumeric strings.
+ * Parses a lookup table (LUT) from a `ViewerChannelSetting` object, where the
+ * `lut` field is an array of two alphanumeric strings.
  *
- * @returns a Lut object if the `lut` field is valid; otherwise, returns undefined.
+ * @returns a Lut object if the `lut` field is valid; otherwise, returns
+ * undefined.
  *
  * Min and max values are determined as following:
- * - Plain numbers are indices of histogram bins, in the range [0, 255].
- * - `v{n}` represents a raw intensity value, where `n` is an integer.
- * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100] range.
+ * - Plain numbers are indices of histogram bins, typically in the range [0,
+ *   255].
+ * - `v{n}` represents a raw intensity value, where `n` is a number.
+ * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100]
+ *   range.
  * - `m{n}` represents the median multiplied by `n / 100`.
- * - `autoij` in either the min or max fields will use the "auto" algorithm
- * from ImageJ to select the min and max.
+ * - `autoij` in either the min or max fields will use the "auto" algorithm from
+ *   ImageJ to select the min and max.
  *
  * @example
  * ```

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -31,6 +31,9 @@ function parseLutValue(value: string, histogram: Histogram): number {
     // percentile
     const parsedValue = parseFloat(value.substring(1)) / 100.0;
     return histogram.findBinOfPercentile(parsedValue);
+  } else if (firstChar === "v") {
+    const parsedValue = parseFloat(value.substring(1));
+    return histogram.findBinOfValue(parsedValue);
   } else {
     // plain number
     return parseFloat(value);
@@ -44,15 +47,17 @@ function parseLutValue(value: string, histogram: Histogram): number {
  * @returns a Lut object if the `lut` field is valid; otherwise, returns undefined.
  *
  * Min and max values are determined as following:
- * - Plain numbers are direct intensity values.
+ * - Plain numbers are indices of histogram bins, in the range [0, 255].
+ * - `v{n}` represents a raw intensity value, where `n` is an integer.
  * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100] range.
  * - `m{n}` represents the median multiplied by `n / 100`.
  * - `autoij` in either the min or max fields will use the "auto" algorithm
- * from ImageJ to select the min AND max.
+ * from ImageJ to select the min and max.
  *
  * @example
  * ```
- * "0:255"    // min: intensity 0, max: intensity 255.
+ * "0:255"    // min: bin 0, max: bin 255.
+ * "v100:v150" // min: intensity 100, max: intensity 150.
  * "p50:p90"  // min: 50th percentile, max: 90th percentile.
  * "m1:p75"   // min: median, max: 75th percentile.
  * "autoij:0" // use Auto-IJ to calculate min and max.

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -22,7 +22,8 @@ export interface ViewerChannelSetting {
    * Min and max values for the intensity lookup table, which maps from raw intensity values
    * in the volume to opacity and color. Defaults to [0, 255].
    *
-   * - Plain numbers are treated as direct intensity values.
+   * - Plain numbers are indices of histogram bins, in the range [0, 255].
+   * - `v{n}` represents a raw intensity value, where `n` is an integer.
    * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100] range.
    * - `m{n}` represents the median multiplied by `n / 100`.
    * - `autoij` in either the min or max fields will use the "auto" algorithm

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -501,14 +501,14 @@ describe("Viewer state", () => {
     });
 
     it("shortens long numbers in the slice and region parameters", () => {
-      // Floats should be rounded to 5 significant digits or less
+      // Floats should be rounded to 7 significant digits or less
       let state: Partial<ViewerState> = {
         region: { x: [0.4566666666, 0.8667332], y: [0.49999999, 0.8999999], z: [0.3000000001, 0.16467883] },
         slice: { x: 0.41111186, y: 0.49999999, z: 0.677402 },
       };
       let serializedState = serializeViewerState(state, true);
-      expect(serializedState.reg).toEqual("0.45667:0.86673,0.5:0.9,0.3:0.16468");
-      expect(serializedState.slice).toEqual("0.41111,0.5,0.6774");
+      expect(serializedState.reg).toEqual("0.4566667:0.8667332,0.5:0.8999999,0.3:0.1646788");
+      expect(serializedState.slice).toEqual("0.4111119,0.5,0.677402");
     });
   });
 

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -150,7 +150,9 @@ export class ViewerChannelSettingParams {
    * separated by a colon, where the first value is the minimum and the second is the maximum.
    * Defaults to [0, 255].
    *
-   * - Plain numbers are treated as direct intensity values.
+   * Min and max values are determined as following:
+   * - Plain numbers are indices of histogram bins, in the range [0, 255].
+   * - `v{n}` represents a raw intensity value, where `n` is an integer.
    * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100] range.
    * - `m{n}` represents the median multiplied by `n / 100`.
    * - `autoij` in either the min or max fields will use the "auto" algorithm

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -542,7 +542,7 @@ function parseStringRegion(region: string | undefined): PerAxis<[number, number]
  * Formats a float or integer value to a string with a maximum precision for float values.
  * @param value The number to format.
  * @param maxPrecision The maximum number of significant digits to display for float values.
- * Default is 5.
+ * Default is 7.
  * @returns
  * - For integers, the integer value as a string.
  * - For floats, the float value as a string with a maximum of `maxPrecision` significant digits
@@ -555,7 +555,7 @@ function parseStringRegion(region: string | undefined): PerAxis<[number, number]
  * formatFloat(1.3999999999999999, 3) // "1.4"
  * ```
  */
-function formatFloat(value: number, maxPrecision: number = 5): string {
+function formatFloat(value: number, maxPrecision: number = 7): string {
   if (Number.isInteger(value)) {
     return value.toString();
   }

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -146,20 +146,22 @@ export class ViewerChannelSettingParams {
   /** Isosurface alpha, in the [0, 1 range]. Set to `1.0` by default.*/
   [ViewerChannelSettingKeys.IsosurfaceAlpha]?: string = undefined;
   /**
-   * Lookup table (LUT) to map from volume intensity to opacity. Should be two alphanumeric values
-   * separated by a colon, where the first value is the minimum and the second is the maximum.
-   * Defaults to [0, 255].
+   * Lookup table (LUT) to map from volume intensity to opacity. Should be two
+   * alphanumeric values separated by a colon, where the first value is the
+   * minimum and the second is the maximum. Defaults to [0, 255].
    *
    * Min and max values are determined as following:
-   * - Plain numbers are indices of histogram bins, in the range [0, 255].
-   * - `v{n}` represents a raw intensity value, where `n` is an integer.
-   * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100] range.
+   * - Plain numbers are indices of histogram bins, typically in the range [0,
+   *   255].
+   * - `v{n}` represents a raw intensity value, where `n` is a number.
+   * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100]
+   *   range.
    * - `m{n}` represents the median multiplied by `n / 100`.
    * - `autoij` in either the min or max fields will use the "auto" algorithm
-   * from ImageJ to select the min and max.
+   *   from ImageJ to select the min and max.
    *
-   * Values will be used to determine the initial control points and ramp if those
-   * fields are not provided.
+   * Values will be used to determine the initial control points and ramp if
+   * those fields are not provided.
    *
    * @example
    * ```


### PR DESCRIPTION
Problem
=======
Closes #407, "Include direct data values for ramp/control points in URL".

*Estimated review size: small, 5-10 minutes*

Solution
========
- Adds a new format for accepting raw data values as `v{n}` in the `lut` URL argument.
- Updates vole-core to access the new histogram API (`Histogram.getFractionalBinOfValue()`)
  - Use `Histogram.getValueFromBinIndex()` in TfEditor calculations
- Updated documentation. 

## Type of change

New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open preview link: https://allen-cell-animated.github.io/vole-app/pr-preview/pr-408/?url=https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/raw.ome.zarr,https://allencell.s3.amazonaws.com/aics/nuc-morph-dataset/hipsc_fov_nuclei_timelapse_dataset/hipsc_fov_nuclei_timelapse_data_used_for_analysis/baseline_colonies_fov_timelapse_dataset/20200323_09_small/seg.ome.zarr&c0=ven:1,lut:v100:v150&c1=ven:1,lut:v30000:v40000&c2=ven:1,lut:v10.2:v20.3
2. You should see the range `100, 150` for channel 0, `30000, 40000` for channel 2, and `10, 20` for channel 3.
3. Click the share button to copy the URL. Paste it into a new browser tab.
4. The ranges should remain the same.
