### PR TITLE
Full range isovalue (simple version)

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -235,14 +235,15 @@ const App: React.FC<AppProps> = (props) => {
       if (isInitialLoad || noLut || getChannelsAwaitingResetOnLoad().has(channelIndex)) {
         // This channel needs its LUT initialized
         const { ramp, controlPoints } = initializeLut(image, channelIndex, getCurrentViewerChannelSettings());
-        const { dtype } = thisChannel;
+        const range = DTYPE_RANGE[thisChannel.dtype];
 
         changeChannelSetting(channelIndex, {
           controlPoints: controlPoints,
           ramp: controlPointsToRamp(ramp),
           // set the default range of the transfer function editor to cover the full range of the data type
-          plotMin: DTYPE_RANGE[dtype].min,
-          plotMax: DTYPE_RANGE[dtype].max,
+          plotMin: range.min,
+          plotMax: range.max,
+          isovalue: range.min + (range.max - range.min) / 2,
         });
       } else {
         // This channel has already been initialized, but its LUT was just remapped and we need to update some things

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -3,7 +3,7 @@ import { Button, Checkbox, List } from "antd";
 import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import React, { useCallback, useState } from "react";
 
-import { ISOSURFACE_OPACITY_SLIDER_MAX } from "../../shared/constants";
+import { DTYPE_RANGE, ISOSURFACE_OPACITY_SLIDER_MAX } from "../../shared/constants";
 import { IsosurfaceFormat } from "../../shared/types";
 import { colorArrayToObject, ColorObject, colorObjectToArray } from "../../shared/utils/colorRepresentations";
 import {
@@ -105,28 +105,32 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
     );
   };
 
-  const renderSurfaceControls = (): React.ReactNode => (
-    <div>
-      <SliderRow
-        label="Isovalue"
-        max={255}
-        start={channelState.isovalue}
-        onChange={onIsovalueChange}
-        formatInteger={true}
-      />
-      <SliderRow
-        label="Opacity"
-        max={ISOSURFACE_OPACITY_SLIDER_MAX}
-        start={channelState.opacity * ISOSURFACE_OPACITY_SLIDER_MAX}
-        onChange={onOpacityChange}
-        formatInteger={true}
-      />
-      <div className="button-row">
-        <Button onClick={() => saveIsosurface(index, "GLTF")}>Export GLTF</Button>
-        <Button onClick={() => saveIsosurface(index, "STL")}>Export STL</Button>
+  const renderSurfaceControls = (): React.ReactNode => {
+    const range = DTYPE_RANGE[props.channelDataForChannel.dtype];
+    return (
+      <div>
+        <SliderRow
+          label="Isovalue"
+          min={range.min}
+          max={range.max}
+          start={channelState.isovalue}
+          onChange={onIsovalueChange}
+          formatInteger={true}
+        />
+        <SliderRow
+          label="Opacity"
+          max={ISOSURFACE_OPACITY_SLIDER_MAX}
+          start={channelState.opacity * ISOSURFACE_OPACITY_SLIDER_MAX}
+          onChange={onOpacityChange}
+          formatInteger={true}
+        />
+        <div className="button-row">
+          <Button onClick={() => saveIsosurface(index, "GLTF")}>Export GLTF</Button>
+          <Button onClick={() => saveIsosurface(index, "STL")}>Export STL</Button>
+        </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   const renderControls = (): React.ReactNode => {
     if (!channelState.volumeEnabled && !channelState.isosurfaceEnabled) {

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -116,6 +116,7 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
           <InputNumber
             value={channelState.isovalue}
             onChange={(isovalue) => isovalue !== null && changeSettingForThisChannel({ isovalue })}
+            formatter={(v) => (v === undefined ? "" : Number(v).toFixed(0))}
             min={range.min}
             max={range.max}
             size="small"

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -1,5 +1,5 @@
 import { Channel } from "@aics/vole-core";
-import { Button, Checkbox, List } from "antd";
+import { Button, Checkbox, InputNumber, List } from "antd";
 import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import React, { useCallback, useState } from "react";
 
@@ -47,10 +47,6 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
   const isosurfaceCheckHandler = ({ target }: CheckboxChangeEvent): void => {
     changeChannelSetting(index, { isosurfaceEnabled: target.checked });
   };
-
-  const onIsovalueChange = ([newValue]: number[]): void => changeSettingForThisChannel({ isovalue: newValue });
-  const onOpacityChange = ([newValue]: number[]): void =>
-    changeSettingForThisChannel({ opacity: newValue / ISOSURFACE_OPACITY_SLIDER_MAX });
 
   const onColorChange = (newRGB: ColorObject, _oldRGB?: ColorObject, index?: number): void => {
     const color = colorObjectToArray(newRGB);
@@ -114,14 +110,24 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
           min={range.min}
           max={range.max}
           start={channelState.isovalue}
-          onChange={onIsovalueChange}
+          onChange={([isovalue]) => changeSettingForThisChannel({ isovalue })}
           formatInteger={true}
-        />
+        >
+          <InputNumber
+            value={channelState.isovalue}
+            onChange={(isovalue) => isovalue !== null && changeSettingForThisChannel({ isovalue })}
+            min={range.min}
+            max={range.max}
+            size="small"
+            controls={false}
+            style={{ width: "64px", marginLeft: "8px" }}
+          />
+        </SliderRow>
         <SliderRow
           label="Opacity"
           max={ISOSURFACE_OPACITY_SLIDER_MAX}
           start={channelState.opacity * ISOSURFACE_OPACITY_SLIDER_MAX}
-          onChange={onOpacityChange}
+          onChange={([opacity]) => changeSettingForThisChannel({ opacity: opacity / ISOSURFACE_OPACITY_SLIDER_MAX })}
           formatInteger={true}
         />
         <div className="button-row">

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -1,9 +1,10 @@
-import React from "react";
 import { Checkbox } from "antd";
+import React from "react";
+
+import { ViewerSettingUpdater } from "./ViewerStateProvider/types";
 
 import SliderRow from "./shared/SliderRow";
 import { connectToViewerState } from "./ViewerStateProvider";
-import { ViewerSettingUpdater } from "./ViewerStateProvider/types";
 
 type GlobalVolumeControlKey = "maskAlpha" | "brightness" | "density" | "levels";
 
@@ -53,7 +54,7 @@ const GlobalVolumeControls: React.FC<GlobalVolumeControlsProps> = (props) => {
       {showControls.densitySlider && createSliderRow("density", density, 100, "density")}
       {showControls.levelsSliders && createSliderRow("levels", levels, 255, "levels")}
       {showControls.interpolationControl && (
-        <SliderRow label="interpolate">
+        <SliderRow label="interpolate" hideSlider={true}>
           <Checkbox
             checked={props.interpolationEnabled}
             onChange={({ target }) => props.changeViewerSetting("interpolationEnabled", target.checked)}

--- a/src/aics-image-viewer/components/shared/SliderRow/index.tsx
+++ b/src/aics-image-viewer/components/shared/SliderRow/index.tsx
@@ -27,18 +27,20 @@ const SliderRow: React.FC<SliderRowProps> = (props) => (
     <div className="control-name">{props.label}</div>
     <div className="control">
       {props.start !== undefined && !props.hideSlider && (
-        <SmarterSlider
-          range={{ min: props.min ?? 0, max: props.max }}
-          start={props.start}
-          connect={true}
-          tooltips={true}
-          behaviour="drag"
-          format={props.formatInteger ? INTEGER_FORMATTER : undefined}
-          onUpdate={props.onUpdate}
-          onChange={props.onChange}
-        />
+        <div className="control-slider">
+          <SmarterSlider
+            range={{ min: props.min ?? 0, max: props.max }}
+            start={props.start}
+            connect={true}
+            tooltips={true}
+            behaviour="drag"
+            format={props.formatInteger ? INTEGER_FORMATTER : undefined}
+            onUpdate={props.onUpdate}
+            onChange={props.onChange}
+          />
+        </div>
       )}
-      {props.children}
+      {props.children && <div className="control-extra">{props.children}</div>}
     </div>
   </div>
 );

--- a/src/aics-image-viewer/components/shared/SliderRow/index.tsx
+++ b/src/aics-image-viewer/components/shared/SliderRow/index.tsx
@@ -26,20 +26,19 @@ const SliderRow: React.FC<SliderRowProps> = (props) => (
   <div className="viewer-control-row">
     <div className="control-name">{props.label}</div>
     <div className="control">
-      {props.start === undefined
-        ? props.children
-        : !props.hideSlider && (
-            <SmarterSlider
-              range={{ min: props.min ?? 0, max: props.max }}
-              start={props.start}
-              connect={true}
-              tooltips={true}
-              behaviour="drag"
-              format={props.formatInteger ? INTEGER_FORMATTER : undefined}
-              onUpdate={props.onUpdate}
-              onChange={props.onChange}
-            />
-          )}
+      {props.start !== undefined && !props.hideSlider && (
+        <SmarterSlider
+          range={{ min: props.min ?? 0, max: props.max }}
+          start={props.start}
+          connect={true}
+          tooltips={true}
+          behaviour="drag"
+          format={props.formatInteger ? INTEGER_FORMATTER : undefined}
+          onUpdate={props.onUpdate}
+          onChange={props.onChange}
+        />
+      )}
+      {props.children}
     </div>
   </div>
 );

--- a/src/aics-image-viewer/components/shared/SliderRow/index.tsx
+++ b/src/aics-image-viewer/components/shared/SliderRow/index.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import { NouisliderProps } from "nouislider-react";
+import React from "react";
+
 import SmarterSlider from "../SmarterSlider";
 
 import "./styles.css";
@@ -9,6 +10,7 @@ type SliderRowProps = {
   start?: number | number[];
   step?: number;
   formatInteger?: boolean;
+  min?: number;
   max?: number;
   onUpdate?: NouisliderProps["onUpdate"];
   onChange?: NouisliderProps["onChange"];
@@ -28,7 +30,7 @@ const SliderRow: React.FC<SliderRowProps> = (props) => (
         ? props.children
         : !props.hideSlider && (
             <SmarterSlider
-              range={{ min: 0, max: props.max }}
+              range={{ min: props.min ?? 0, max: props.max }}
               start={props.start}
               connect={true}
               tooltips={true}

--- a/src/aics-image-viewer/components/shared/SliderRow/styles.css
+++ b/src/aics-image-viewer/components/shared/SliderRow/styles.css
@@ -15,5 +15,11 @@
 
   .control {
     flex: 5;
+    display: flex;
+    align-items: center;
+
+    .control-slider {
+      flex-grow: 1;
+    }
   }
 }


### PR DESCRIPTION
Review time: small (10min)

Resolves allen-cell-animated/vole-core#340: currently, the slider for isosurfaces is locked to a range of 0-255, even though we now support multiple different data types with much larger ranges. This change:
- sets the range of the isosurface slider to match the channel data type
- adds a numeric input next to the isosurface slider to allow finer control over the isovalue
- makes some updates to our generic "control row" component to allow the numeric input there
- sets the isovalue to the middle of the available range by default
