### PR TITLE
transfer function range reset bug

### DIFF
--- a/src/aics-image-viewer/components/ViewerStateProvider/ResetStateProvider.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/ResetStateProvider.ts
@@ -128,9 +128,12 @@ export default class ResetStateProvider implements ResetState {
         getDefaultChannelColor(index),
         this.savedViewerChannelSettings
       );
-      return initialChannelSetting;
+      return {
+        ...initialChannelSetting,
+        plotMin: channelSettings[index].plotMin,
+        plotMax: channelSettings[index].plotMax,
+      };
     });
-
     this.resetToState(newViewerState, newChannelSettings);
     this.useDefaultViewerChannelSettings = false;
   }


### PR DESCRIPTION
Problem
=======
Advances #423 

Solution
========
The settings reset button was grabbing the global default min/max that is data type agnostic (always 0, 255).

This change makes the reset use the current value, i.e. no change when reset settings is clicked.

* Bug fix (non-breaking change which fixes an issue)
