### PR TITLE
Feature/hide-title

### DIFF
--- a/website/components/AppWrapper.tsx
+++ b/website/components/AppWrapper.tsx
@@ -69,10 +69,12 @@ export default function AppWrapper(): ReactElement {
 
   const onImageTitleChange = useCallback(
     (title: string | undefined) => {
-      setImageTitle(title);
-      document.title = title ? `Vol-E — ${title}` : "Vol-E";
+      if (!searchParams.get("hideTitle")) {
+        setImageTitle(title);
+        document.title = title ? `Vol-E — ${title}` : "Vol-E";
+      }
     },
-    [setImageTitle]
+    [setImageTitle, searchParams]
   );
 
   const onLoad = (appProps: AppDataProps): void => {

--- a/website/components/LandingPage/content.tsx
+++ b/website/components/LandingPage/content.tsx
@@ -61,6 +61,7 @@ export const landingPageContent: ProjectEntry[] = [
           parentImageDownloadHref: "",
           ...nucmorphBaseViewerSettings,
         },
+        hideTitle: true,
       },
       {
         name: "Medium colony",
@@ -78,6 +79,7 @@ export const landingPageContent: ProjectEntry[] = [
           parentImageDownloadHref: "",
           ...nucmorphBaseViewerSettings,
         },
+        hideTitle: true,
       },
       {
         name: "Large colony",
@@ -95,6 +97,7 @@ export const landingPageContent: ProjectEntry[] = [
           parentImageDownloadHref: "",
           ...nucmorphBaseViewerSettings,
         },
+        hideTitle: true,
       },
     ],
   },

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -256,10 +256,11 @@ export default function LandingPage(): ReactElement {
     });
   }, [navigation, searchParams]);
 
-  const onClickLoad = (appProps: AppDataProps): void => {
+  const onClickLoad = (appProps: AppDataProps, hideTitle?: boolean): void => {
     // TODO: Make URL search params from the appProps and append it to the viewer URL so the URL can be shared directly.
     // Alternatively, AppWrapper should manage syncing URL and viewer props.
-    navigation(`/viewer?url=${encodeImageUrlProp(appProps.imageUrl)}`, {
+    const hideTitleParam = hideTitle ? "&hideTitle=true" : "";
+    navigation(`/viewer?url=${encodeImageUrlProp(appProps.imageUrl)}${hideTitleParam}`, {
       state: appProps,
     });
   };
@@ -272,7 +273,7 @@ export default function LandingPage(): ReactElement {
       <DatasetCard key={index}>
         <h3>{dataset.name}</h3>
         {dataset.description && <p>{dataset.description}</p>}
-        <Button type="primary" onClick={() => onClickLoad(dataset.loadParams)}>
+        <Button type="primary" onClick={() => onClickLoad(dataset.loadParams, dataset.hideTitle)}>
           Load<VisuallyHidden> dataset {dataset.name}</VisuallyHidden>
         </Button>
       </DatasetCard>
@@ -312,10 +313,10 @@ export default function LandingPage(): ReactElement {
       </p>
     ) : null;
 
-    const loadParams = project.loadParams;
+    const { loadParams, hideTitle } = project;
     const loadButton = loadParams ? (
       <div>
-        <Button type="primary" onClick={() => onClickLoad(loadParams)}>
+        <Button type="primary" onClick={() => onClickLoad(loadParams, hideTitle)}>
           Load<VisuallyHidden> dataset {project.name}</VisuallyHidden>
         </Button>
       </div>

--- a/website/types.ts
+++ b/website/types.ts
@@ -8,6 +8,7 @@ export type DatasetEntry = {
   name: string;
   description?: string;
   loadParams: AppDataProps;
+  hideTitle?: boolean;
 };
 
 export type PublicationInfo = {
@@ -23,4 +24,5 @@ export type ProjectEntry = {
   loadParams?: AppDataProps;
   datasets?: DatasetEntry[];
   inReview?: boolean;
+  hideTitle?: boolean;
 };


### PR DESCRIPTION
Review time: small (5-10min)

Follows on from #409, which added image titles to the top of the website. Turns out that our example images from nucmorph are just called "raw," so this change disables showing the title when those images are opened.
