### PR TITLE
Zustand 3: reset state

### DIFF
--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -1,13 +1,13 @@
 import { Lut, View3d, Volume } from "@aics/vole-core";
 import React, { useEffect } from "react";
+import { useShallow } from "zustand/shallow";
 
 import { controlPointsToLut, rampToControlPoints } from "../../shared/utils/controlPointsToLut";
-import { ChannelState } from "../ViewerStateProvider/types";
+import { useViewerState, type ViewerStore } from "../../state/store";
 import { UseImageEffectType } from "./types";
 
 interface ChannelUpdaterProps {
   index: number;
-  channelState: ChannelState;
   view3d: View3d;
   image: Volume | null;
   version: number;
@@ -17,7 +17,9 @@ interface ChannelUpdaterProps {
  * A component that doesn't render anything, but reacts to the provided `ChannelState`
  * and keeps it in sync with the viewer.
  */
-const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, view3d, image, version }) => {
+const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, view3d, image, version }) => {
+  const channelStateSelector = useShallow((state: ViewerStore) => state.channelSettings[index]);
+  const channelState = useViewerState(channelStateSelector);
   const { volumeEnabled, isosurfaceEnabled, isovalue, colorizeEnabled, colorizeAlpha, opacity, color } = channelState;
 
   // Effects to update channel settings should check if image is present and channel is loaded first

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -4,13 +4,13 @@ import React from "react";
 
 import { PRESET_COLOR_MAP } from "../../shared/constants";
 import { MetadataRecord } from "../../shared/types";
+import { select, useViewerState } from "../../state/store";
 
 import ChannelsWidget from "../ChannelsWidget";
 import CustomizeWidget, { CustomizeWidgetProps } from "../CustomizeWidget";
 import GlobalVolumeControls, { GlobalVolumeControlsProps } from "../GlobalVolumeControls";
 import MetadataViewer from "../MetadataViewer";
 import ViewerIcon from "../shared/ViewerIcon";
-import { connectToViewerState } from "../ViewerStateProvider";
 
 import "./styles.css";
 
@@ -29,7 +29,6 @@ interface ControlPanelProps
   getMetadata: () => MetadataRecord;
   collapsed: boolean;
   setCollapsed: (value: boolean) => void;
-  resetToDefaultViewerState: () => void;
 }
 
 const enum ControlTab {
@@ -50,6 +49,7 @@ function ControlPanel(props: ControlPanelProps): React.ReactElement {
     _setTab(newTab);
     props.setCollapsed(false);
   };
+  const resetToDefaultViewerState = useViewerState(select("resetToDefaultViewerState"));
 
   const controlPanelContainerRef = React.useRef<HTMLDivElement>(null);
   const getDropdownContainer = controlPanelContainerRef.current ? () => controlPanelContainerRef.current! : undefined;
@@ -128,7 +128,7 @@ function ControlPanel(props: ControlPanelProps): React.ReactElement {
             title="Clears ALL rendering settings and channel configuration to the default viewer state.
             This will replace any edits to channel settings, color presets, and rendering adjustments."
           >
-            <Button onClick={props.resetToDefaultViewerState}>Clear all settings</Button>
+            <Button onClick={resetToDefaultViewerState}>Clear all settings</Button>
           </Tooltip>
         </div>
       </Flex>
@@ -176,4 +176,4 @@ function ControlPanel(props: ControlPanelProps): React.ReactElement {
   );
 }
 
-export default connectToViewerState(ControlPanel, ["resetToDefaultViewerState"]);
+export default ControlPanel;

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -21,6 +21,7 @@ type ToolbarProps = {
 
   resetCamera: () => void;
   downloadScreenshot: () => void;
+  resetToSavedViewerState: () => void;
 
   visibleControls: {
     autoRotateButton: boolean;
@@ -64,7 +65,6 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
   const showAxes = useViewerState(select("showAxes"));
   const showBoundingBox = useViewerState(select("showBoundingBox"));
   const changeViewerSetting = useViewerState(select("changeViewerSetting"));
-  const resetToSavedViewerState = useViewerState(select("resetToSavedViewerState"));
 
   // Scroll buttons are only visible when toolbar can be scrolled in that direction.
   // This may change on either scroll or resize.
@@ -157,7 +157,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
       <div className="viewer-toolbar" ref={barRef} onWheel={wheelHandler} onScroll={checkScrollBtnVisible}>
         <div className="viewer-toolbar-left" ref={leftRef}>
           <Tooltip placement="bottom" title="Reset to initial settings" trigger={["focus", "hover"]}>
-            <Button className="ant-btn-icon-only btn-borderless" onClick={resetToSavedViewerState}>
+            <Button className="ant-btn-icon-only btn-borderless" onClick={props.resetToSavedViewerState}>
               <ReloadOutlined />
               <span style={visuallyHiddenStyle}>Reset to initial settings</span>
             </Button>

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -7,7 +7,6 @@ import { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import { select, useViewerState } from "../../state/store";
 
 import ViewerIcon from "../shared/ViewerIcon";
-import { connectToViewerState } from "../ViewerStateProvider";
 import DownloadButton from "./DownloadButton";
 import ViewModeRadioButtons from "./ViewModeRadioButtons";
 
@@ -31,9 +30,6 @@ type ToolbarProps = {
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
   };
-
-  // From viewer state
-  resetToSavedViewerState: () => void;
 };
 
 const RESIZE_DEBOUNCE_DELAY = 50;
@@ -68,6 +64,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
   const showAxes = useViewerState(select("showAxes"));
   const showBoundingBox = useViewerState(select("showBoundingBox"));
   const changeViewerSetting = useViewerState(select("changeViewerSetting"));
+  const resetToSavedViewerState = useViewerState(select("resetToSavedViewerState"));
 
   // Scroll buttons are only visible when toolbar can be scrolled in that direction.
   // This may change on either scroll or resize.
@@ -135,7 +132,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
   const classForToggleBtn = (active: boolean): string =>
     "ant-btn-icon-only btn-borderless" + (active ? " btn-active" : "");
 
-  const { resetToSavedViewerState, visibleControls } = props;
+  const { visibleControls } = props;
   const twoDMode = viewMode !== ViewMode.threeD;
 
   const renderGroup1 =
@@ -273,4 +270,4 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
   );
 };
 
-export default connectToViewerState(Toolbar, ["resetToSavedViewerState"]);
+export default Toolbar;

--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -6,6 +6,7 @@ import {
   AXIS_TO_LOADER_PRIORITY,
   CACHE_MAX_SIZE,
   getDefaultChannelColor,
+  getDefaultViewerChannelSettings,
   QUEUE_MAX_LOW_PRIORITY_SIZE,
   QUEUE_MAX_SIZE,
 } from "../shared/constants";
@@ -14,13 +15,18 @@ import { AxisName } from "../shared/types";
 import { useConstructor, useRefWithSetter } from "../shared/utils/hooks";
 import PlayControls from "../shared/utils/playControls";
 import SceneStore from "../shared/utils/sceneStore";
-import { ChannelGrouping, getDisplayName, makeChannelIndexGrouping } from "../shared/utils/viewerChannelSettings";
+import {
+  ChannelGrouping,
+  getDisplayName,
+  makeChannelIndexGrouping,
+  ViewerChannelSettings,
+} from "../shared/utils/viewerChannelSettings";
 import { initializeOneChannelSetting } from "../shared/utils/viewerState";
-import { selectCurrentViewerChannelSettings } from "../state/reset";
 import { select, useViewerState } from "../state/store";
 import { ChannelState } from "./ViewerStateProvider/types";
 
 export type UseVolumeOptions = {
+  viewerChannelSettings?: ViewerChannelSettings;
   /** Callback for when the volume is created. */
   onCreateImage?: (image: Volume) => void;
   /** Callback for when a single channel of the volume has loaded. */
@@ -206,7 +212,10 @@ const useVolume = (
     inInitialLoadRef.current = true;
 
     const setChannelStateForNewImage = (channelNames: string[]): ChannelState[] | undefined => {
-      const viewerChannelSettings = selectCurrentViewerChannelSettings(useViewerState.getState());
+      const { useDefaultViewerChannelSettings } = useViewerState.getState();
+      const viewerChannelSettings = useDefaultViewerChannelSettings
+        ? getDefaultViewerChannelSettings()
+        : options?.viewerChannelSettings;
       const grouping = makeChannelIndexGrouping(channelNames, viewerChannelSettings);
       setChannelGroupedByType(grouping);
 
@@ -274,7 +283,10 @@ const useVolume = (
         : [];
 
       // add mask channel to required channels, if specified
-      const viewerChannelSettings = selectCurrentViewerChannelSettings(useViewerState.getState());
+      const { useDefaultViewerChannelSettings } = useViewerState.getState();
+      const viewerChannelSettings = useDefaultViewerChannelSettings
+        ? getDefaultViewerChannelSettings()
+        : options?.viewerChannelSettings;
       const maskChannelName = viewerChannelSettings?.maskChannelName;
       if (maskChannelName) {
         const maskChannelIndex = channelNames.indexOf(maskChannelName);
@@ -315,6 +327,7 @@ const useVolume = (
     onChannelDataLoaded,
     changeViewerSetting,
     initChannelSettings,
+    options?.viewerChannelSettings,
   ]);
   // of the above dependencies, we expect only `sceneLoader` to change.
 

--- a/src/aics-image-viewer/state/reset.ts
+++ b/src/aics-image-viewer/state/reset.ts
@@ -6,6 +6,7 @@ import {
   getDefaultCameraState,
   getDefaultChannelColor,
   getDefaultChannelState,
+  getDefaultViewerChannelSettings,
   getDefaultViewerState,
 } from "../shared/constants";
 import { ViewMode } from "../shared/enums";
@@ -22,15 +23,6 @@ export type ResetStateActions = {
    * or the URL parameters.
    */
   setSavedViewerChannelSettings: (settings: ViewerChannelSettings | undefined) => void;
-  /**
-   * Returns the current viewer channel settings that should be used when resetting
-   * the channel transfer functions (control points and ramp).
-   */
-  //   getCurrentViewerChannelSettings: () => ViewerChannelSettings | undefined;
-  /** Channels that should be immediately reset on next render. */
-  //   getChannelsAwaitingReset: () => Set<number>;
-  /** Channels that should be reset once new data is loaded. */
-  //   getChannelsAwaitingResetOnLoad: () => Set<number>;
   /**
    * Removes the channel from the list of channels to be reset (as given by
    * `getChannelsAwaitingReset()` or `getChannelsAwaitingResetOnLoad()`).
@@ -109,18 +101,18 @@ export const createResetSlice: StateCreator<ViewerStore, [], [], ResetStateSlice
   savedViewerChannelSettings: undefined,
   useDefaultViewerChannelSettings: false,
 
-  setSavedViewerChannelSettings: (settings: ViewerChannelSettings | undefined): void => {
+  setSavedViewerChannelSettings: (settings) => {
     set({ savedViewerChannelSettings: settings });
   },
 
-  onResetChannel: (channelIndex: number): void => {
+  onResetChannel: (channelIndex) => {
     set(({ channelsToReset, channelsToResetOnLoad }) => ({
       channelsToReset: channelsToReset.filter((ch) => ch !== channelIndex),
       channelsToResetOnLoad: channelsToResetOnLoad.filter((ch) => ch !== channelIndex),
     }));
   },
 
-  resetToSavedViewerState: (): void => {
+  resetToSavedViewerState: () => {
     set((currentState) => {
       const { channelSettings, savedViewerState, savedViewerChannelSettings } = currentState;
       const newViewerState = {
@@ -144,7 +136,7 @@ export const createResetSlice: StateCreator<ViewerStore, [], [], ResetStateSlice
     });
   },
 
-  resetToDefaultViewerState: (): void => {
+  resetToDefaultViewerState: () => {
     set((currentState) => {
       const { channelSettings } = currentState;
       const defaultViewerState = {
@@ -164,3 +156,14 @@ export const createResetSlice: StateCreator<ViewerStore, [], [], ResetStateSlice
     });
   },
 });
+
+/**
+ * Selects the current viewer channel settings that should be used when resetting
+ * the channel transfer functions (control points and ramp).
+ */
+export const selectCurrentViewerChannelSettings = (store: ResetStateSlice): ViewerChannelSettings | undefined => {
+  if (store.useDefaultViewerChannelSettings) {
+    return getDefaultViewerChannelSettings();
+  }
+  return store.savedViewerChannelSettings;
+};

--- a/src/aics-image-viewer/state/reset.ts
+++ b/src/aics-image-viewer/state/reset.ts
@@ -1,0 +1,166 @@
+import { isEqual } from "lodash";
+import type { StateCreator } from "zustand";
+
+import { ChannelState, ViewerState } from "../components/ViewerStateProvider/types";
+import {
+  getDefaultCameraState,
+  getDefaultChannelColor,
+  getDefaultChannelState,
+  getDefaultViewerState,
+} from "../shared/constants";
+import { ViewMode } from "../shared/enums";
+import { ViewerChannelSettings } from "../shared/utils/viewerChannelSettings";
+import { getEnabledChannelIndices, initializeOneChannelSetting } from "../shared/utils/viewerState";
+import { ViewerStore } from "./store";
+import { validateState } from "./util";
+
+// TODO move to types?
+export type ResetStateActions = {
+  /**
+   * Sets the initial viewer channel settings that will be applied when calling
+   * `resetToSavedViewerState()`. Initial settings should be set from the viewer props (when embedded)
+   * or the URL parameters.
+   */
+  setSavedViewerChannelSettings: (settings: ViewerChannelSettings | undefined) => void;
+  /**
+   * Returns the current viewer channel settings that should be used when resetting
+   * the channel transfer functions (control points and ramp).
+   */
+  //   getCurrentViewerChannelSettings: () => ViewerChannelSettings | undefined;
+  /** Channels that should be immediately reset on next render. */
+  //   getChannelsAwaitingReset: () => Set<number>;
+  /** Channels that should be reset once new data is loaded. */
+  //   getChannelsAwaitingResetOnLoad: () => Set<number>;
+  /**
+   * Removes the channel from the list of channels to be reset (as given by
+   * `getChannelsAwaitingReset()` or `getChannelsAwaitingResetOnLoad()`).
+   */
+  onResetChannel: (channelIndex: number) => void;
+
+  /**
+   * Resets the viewer and all channels to a saved initial state, determined
+   * by viewer props.
+   * The initial settings for channels can be set with `setSavedViewerChannelSettings()`.
+   */
+  resetToSavedViewerState: () => void;
+  /**
+   * Resets the viewer and all channels to the default state, as though
+   * loaded from scratch with no initial parameters set.
+   * Uses the default channel settings as given by `getDefaultViewerChannelSettings()`.
+   */
+  resetToDefaultViewerState: () => void;
+};
+
+export type ResetState = {
+  savedViewerState: Partial<ViewerState>;
+  savedViewerChannelSettings: ViewerChannelSettings | undefined;
+  useDefaultViewerChannelSettings: boolean;
+  channelsToReset: number[];
+  channelsToResetOnLoad: number[];
+};
+
+export type ResetStateSlice = ResetStateActions & ResetState;
+
+const resetState = (
+  currentState: ViewerState & { channelSettings: ChannelState[] },
+  newState: ViewerState,
+  newChannelStates: ChannelState[]
+): ViewerState & Partial<ResetState> & { channelSettings: ChannelState[] } => {
+  const { channelSettings, viewMode, time, slice } = currentState;
+
+  // Needs reset on reload if one of the view modes is 2D while the other is 3D,
+  // if the timestamp is different, or if we're on a different z slice.
+  // TODO: Handle stopping playback? Requires playback to be part of ViewerStateContext
+  const isInDifferentViewMode =
+    viewMode !== newState.viewMode && (viewMode === ViewMode.xy || newState.viewMode === ViewMode.xy);
+  const isAtDifferentTime = time !== newState.time;
+  const isAtDifferentZSlice = newState.viewMode === ViewMode.xy && !isEqual(newState.slice.z, slice.z);
+  const willNeedResetOnLoad = isInDifferentViewMode || isAtDifferentTime || isAtDifferentZSlice;
+
+  const viewerState = validateState(currentState, newState);
+  // Match the names in the new state with the existing state so we do not override the names.
+  // Also don't reset the control points or ramps, since these will be reset in the app.
+  const channelState = newChannelStates.map((state, index) => ({
+    ...state,
+    name: channelSettings[index].name,
+    controlPoints: channelSettings[index].controlPoints,
+    ramp: channelSettings[index].ramp,
+  }));
+
+  let channelsToReset = [...Array(newChannelStates.length).keys()];
+  let channelsToResetOnLoad: number[] = [];
+  if (willNeedResetOnLoad) {
+    channelsToResetOnLoad = getEnabledChannelIndices(newChannelStates);
+    channelsToReset = channelsToResetOnLoad.filter((ch) => !channelsToResetOnLoad.includes(ch));
+  }
+
+  return {
+    ...(viewerState as ViewerState),
+    channelSettings: channelState,
+    channelsToReset,
+    channelsToResetOnLoad,
+  };
+};
+
+export const createResetSlice: StateCreator<ViewerStore, [], [], ResetStateSlice> = (set) => ({
+  channelsToReset: [],
+  channelsToResetOnLoad: [],
+  savedViewerState: {},
+  savedViewerChannelSettings: undefined,
+  useDefaultViewerChannelSettings: false,
+
+  setSavedViewerChannelSettings: (settings: ViewerChannelSettings | undefined): void => {
+    set({ savedViewerChannelSettings: settings });
+  },
+
+  onResetChannel: (channelIndex: number): void => {
+    set(({ channelsToReset, channelsToResetOnLoad }) => ({
+      channelsToReset: channelsToReset.filter((ch) => ch !== channelIndex),
+      channelsToResetOnLoad: channelsToResetOnLoad.filter((ch) => ch !== channelIndex),
+    }));
+  },
+
+  resetToSavedViewerState: (): void => {
+    set((currentState) => {
+      const { channelSettings, savedViewerState, savedViewerChannelSettings } = currentState;
+      const newViewerState = {
+        ...getDefaultViewerState(),
+        cameraState: getDefaultCameraState(savedViewerState.viewMode ?? ViewMode.threeD),
+        ...savedViewerState,
+      };
+      const newChannelSettings = channelSettings.map((_, index) => {
+        return initializeOneChannelSetting(
+          channelSettings[index].name,
+          index,
+          getDefaultChannelColor(index),
+          savedViewerChannelSettings
+        );
+      });
+
+      return {
+        ...resetState(currentState, newViewerState, newChannelSettings),
+        useDefaultViewerChannelSettings: true,
+      };
+    });
+  },
+
+  resetToDefaultViewerState: (): void => {
+    set((currentState) => {
+      const { channelSettings } = currentState;
+      const defaultViewerState = {
+        ...getDefaultViewerState(),
+        cameraState: getDefaultCameraState(ViewMode.threeD),
+      };
+      const defaultChannelStates = channelSettings.map((_, index) => {
+        const defaultState = getDefaultChannelState(index);
+        defaultState.volumeEnabled = index < 3;
+        return defaultState;
+      });
+
+      return {
+        ...resetState(currentState, defaultViewerState, defaultChannelStates),
+        useDefaultViewerChannelSettings: true,
+      };
+    });
+  },
+});

--- a/src/aics-image-viewer/state/store.ts
+++ b/src/aics-image-viewer/state/store.ts
@@ -3,63 +3,9 @@ import { subscribeWithSelector } from "zustand/middleware";
 
 import { ChannelState, ViewerState } from "../components/ViewerStateProvider/types";
 import { getDefaultViewerState } from "../shared/constants";
-import { RenderMode, ViewMode } from "../shared/enums";
 import { ColorArray } from "../shared/utils/colorRepresentations";
-
-// TODO move back to a new `types` module (?)
-type ViewerSettingChangeHandlers = {
-  [K in keyof ViewerState]?: (value: Partial<ViewerState[K]>, settings: ViewerState) => Partial<ViewerState>;
-};
-
-const isRecord = <T>(val: T): val is Extract<T, Record<string, unknown>> =>
-  typeof val === "object" && val !== null && !Array.isArray(val);
-
-const VIEWER_SETTINGS_CHANGE_HANDLERS: ViewerSettingChangeHandlers = {
-  // Do not allow path trace render mode in 2D view modes
-  viewMode: (viewMode, { renderMode }) => {
-    const switchToVolumetric = viewMode !== ViewMode.threeD && renderMode === RenderMode.pathTrace;
-    return {
-      viewMode,
-      renderMode: switchToVolumetric ? RenderMode.volumetric : renderMode,
-    };
-  },
-
-  // Don't switch to path trace rendering in any view mode other than 3d; if we do switch, turn off autorotate
-  renderMode: (renderMode, { viewMode, autorotate }) => {
-    const willPathtrace = renderMode === RenderMode.pathTrace;
-    if (willPathtrace && viewMode === ViewMode.threeD) {
-      return {};
-    }
-
-    return {
-      renderMode,
-      autorotate: autorotate && !willPathtrace,
-    };
-  },
-
-  // Do not allow autorotate while in pathtrace mode (button should be disabled, but this provides extra security)
-  autorotate: (autorotate, { renderMode }) => ({
-    autorotate: autorotate && renderMode !== RenderMode.pathTrace,
-  }),
-};
-
-const validateStateValue = <K extends keyof ViewerState>(
-  currentState: ViewerState,
-  key: K,
-  value: Partial<ViewerState[K]>
-): Partial<ViewerState> => {
-  const changeHandler = VIEWER_SETTINGS_CHANGE_HANDLERS[key];
-
-  if (changeHandler) {
-    // some settings have custom change handlers to avoid creating illegal states; if this one has one, call it
-    return changeHandler(value, currentState);
-  } else {
-    // if not, merge the new value to the current one (if applicable) and return
-    const currentValue = currentState[key];
-    const nextValue = isRecord(currentValue) && isRecord(value) ? { ...currentValue, ...value } : value;
-    return { [key]: nextValue };
-  }
-};
+import { createResetSlice, ResetStateSlice } from "./reset";
+import { validateState, validateStateValue } from "./util";
 
 type ViewerStateActions = {
   changeViewerSetting: <K extends keyof ViewerState>(key: K, value: Partial<ViewerState[K]>) => void;
@@ -73,29 +19,19 @@ type ViewerStateActions = {
 };
 
 export type ViewerStore = ViewerState &
-  ViewerStateActions & {
+  ViewerStateActions &
+  ResetStateSlice & {
     channelSettings: ChannelState[];
   };
 
-const createViewerStateStore: StateCreator<ViewerStore> = (set) => ({
+const createViewerStateStore: StateCreator<ViewerStore> = (set, ...etc) => ({
+  ...createResetSlice(set, ...etc),
   ...getDefaultViewerState(),
   channelSettings: [],
 
-  changeViewerSetting: (key, value) => {
-    set((state) => validateStateValue(state, key, value));
-  },
+  changeViewerSetting: (key, value) => set((state) => validateStateValue(state, key, value)),
 
-  mergeViewerSettings: (settings): void => {
-    set((state) => {
-      const validated = {};
-
-      for (const key of Object.keys(settings) as (keyof ViewerState)[]) {
-        Object.assign(validated, validateStateValue(state, key, settings[key]));
-      }
-
-      return validated;
-    });
-  },
+  mergeViewerSettings: (settings): void => set((state) => validateState(state, settings)),
 
   changeChannelSetting: (index, value) => {
     set(({ channelSettings }) => ({

--- a/src/aics-image-viewer/state/util.ts
+++ b/src/aics-image-viewer/state/util.ts
@@ -1,0 +1,70 @@
+import { ViewerState } from "../components/ViewerStateProvider/types";
+import { RenderMode, ViewMode } from "../shared/enums";
+
+// TODO move back to a new `types` module (?)
+type ViewerSettingChangeHandlers = {
+  [K in keyof ViewerState]?: (value: Partial<ViewerState[K]>, settings: ViewerState) => Partial<ViewerState>;
+};
+
+const isRecord = <T>(val: T): val is Extract<T, Record<string, unknown>> =>
+  typeof val === "object" && val !== null && !Array.isArray(val);
+
+const VIEWER_SETTINGS_CHANGE_HANDLERS: ViewerSettingChangeHandlers = {
+  // Do not allow path trace render mode in 2D view modes
+  viewMode: (viewMode, { renderMode }) => {
+    const switchToVolumetric = viewMode !== ViewMode.threeD && renderMode === RenderMode.pathTrace;
+    return {
+      viewMode,
+      renderMode: switchToVolumetric ? RenderMode.volumetric : renderMode,
+    };
+  },
+
+  // Don't switch to path trace rendering in any view mode other than 3d; if we do switch, turn off autorotate
+  renderMode: (renderMode, { viewMode, autorotate }) => {
+    const willPathtrace = renderMode === RenderMode.pathTrace;
+    if (willPathtrace && viewMode === ViewMode.threeD) {
+      return {};
+    }
+
+    return {
+      renderMode,
+      autorotate: autorotate && !willPathtrace,
+    };
+  },
+
+  // Do not allow autorotate while in pathtrace mode (button should be disabled, but this provides extra security)
+  autorotate: (autorotate, { renderMode }) => ({
+    autorotate: autorotate && renderMode !== RenderMode.pathTrace,
+  }),
+};
+
+export const validateStateValue = <K extends keyof ViewerState>(
+  currentState: ViewerState,
+  key: K,
+  value: Partial<ViewerState[K]>
+): Partial<ViewerState> => {
+  const changeHandler = VIEWER_SETTINGS_CHANGE_HANDLERS[key];
+
+  if (changeHandler) {
+    // some settings have custom change handlers to avoid creating illegal states; if this one has one, call it
+    return changeHandler(value, currentState);
+  } else {
+    // if not, merge the new value to the current one (if applicable) and return
+    const currentValue = currentState[key];
+    const nextValue = isRecord(currentValue) && isRecord(value) ? { ...currentValue, ...value } : value;
+    return { [key]: nextValue };
+  }
+};
+
+export const validateState = (
+  currentState: ViewerState,
+  newState: Partial<{ [K in keyof ViewerState]: Partial<ViewerState[K]> }>
+): Partial<ViewerState> => {
+  const validated = {};
+
+  for (const key of Object.keys(newState) as (keyof ViewerState)[]) {
+    Object.assign(validated, validateStateValue(currentState, key, newState[key]));
+  }
+
+  return validated;
+};


### PR DESCRIPTION
Part 3 of converting state management to zustand. This PR rebuilds our current system for resetting state, added and explained in #321, to its default within the zustand store.