### PR TITLE
refactor: Moved FirebaseRequest class into `src/aics-image-viewer`

### DIFF
--- a/public/index.tsx
+++ b/public/index.tsx
@@ -1,7 +1,9 @@
+import firestore from "./firebase/configure-firebase";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, type RouteObject, RouterProvider } from "react-router-dom";
 
+import FirebaseRequest from "../src/aics-image-viewer/shared/utils/firebase";
 import { decodeGitHubPagesUrl, isEncodedPathUrl, tryRemoveHashRouting } from "../website/utils/gh_route_utils";
 
 import StyleProvider from "../src/aics-image-viewer/components/StyleProvider";
@@ -18,6 +20,8 @@ console.log(`vole-core Version ${VOLECORE_VERSION}`);
 
 const basename = VOLEAPP_BASENAME;
 
+const firebaseRequest = new FirebaseRequest(firestore);
+
 // Decode URL path if it was encoded for GitHub pages or uses hash routing.
 const locationUrl = new URL(window.location.toString());
 if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {
@@ -33,12 +37,22 @@ if (locationUrl.hash !== "" || isEncodedPathUrl(locationUrl)) {
 const routes: RouteObject[] = [
   {
     path: "/",
-    lazy: async () => ({ Component: (await import("../website/components/LandingPage")).default }),
+    lazy: async () => {
+      const LandingPage = (await import("../website/components/LandingPage")).default;
+      return {
+        Component: () => <LandingPage firebaseDb={firebaseRequest} />,
+      };
+    },
     errorElement: <ErrorPage />,
   },
   {
     path: "viewer",
-    lazy: async () => ({ Component: (await import("../website/components/AppWrapper")).default }),
+    lazy: async () => {
+      const AppWrapper = (await import("../website/components/AppWrapper")).default;
+      return {
+        Component: () => <AppWrapper firebaseDb={firebaseRequest} />,
+      };
+    },
     errorElement: <ErrorPage />,
   },
   {

--- a/src/aics-image-viewer/shared/utils/firebase/index.ts
+++ b/src/aics-image-viewer/shared/utils/firebase/index.ts
@@ -1,6 +1,7 @@
-import { DocumentReference, QuerySnapshot, DocumentData } from "@firebase/firestore-types";
+import { DocumentData, DocumentReference, FirebaseFirestore, QuerySnapshot } from "@firebase/firestore-types";
 
-import { firestore } from "./configure-firebase";
+// TODO: These types are shared with Cell Feature Explorer. Can they be moved to
+// a shared package?
 
 export interface DatasetMetaData {
   name: string;
@@ -20,8 +21,7 @@ export interface DatasetMetaData {
     totalFOVs: number;
   };
 }
-
-interface FileInfo {
+export interface FileInfo {
   CellId: string;
   CellLineName: string;
   FOVId: string;
@@ -38,6 +38,7 @@ function isDevOrStagingSite(host: string): boolean {
 }
 
 class FirebaseRequest {
+  private firestore: FirebaseFirestore;
   private collectionRef: DocumentReference;
   private featuresDataPath: string;
   private cellLineDataPath: string;
@@ -50,7 +51,9 @@ class FirebaseRequest {
   private featuresDataOrder: string[];
   private albumPath: string;
   private featureDefsPath: string;
-  constructor() {
+
+  constructor(firestore: FirebaseFirestore) {
+    this.firestore = firestore;
     this.featuresDataPath = "";
     this.cellLineDataPath = "";
     this.thumbnailRoot = "";
@@ -66,15 +69,15 @@ class FirebaseRequest {
   }
 
   private getDoc = (docPath: string) => {
-    return firestore.doc(docPath).get();
+    return this.firestore.doc(docPath).get();
   };
 
   private getCollection = (collection: string) => {
-    return firestore.collection(collection).get();
+    return this.firestore.collection(collection).get();
   };
 
   public getAvailableDatasets = () => {
-    return firestore
+    return this.firestore
       .collection("dataset-descriptions")
       .get()
       .then((snapShot: QuerySnapshot) => {
@@ -99,11 +102,11 @@ class FirebaseRequest {
   };
 
   public setCollectionRef = (id: string) => {
-    this.collectionRef = firestore.collection("cfe-datasets").doc(id);
+    this.collectionRef = this.firestore.collection("cfe-datasets").doc(id);
   };
 
   private getManifest = (ref: string) => {
-    return firestore
+    return this.firestore
       .doc(ref)
       .get()
       .then((manifestDoc: DocumentData) => {

--- a/website/components/AppWrapper.tsx
+++ b/website/components/AppWrapper.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { ImageViewerApp, ViewerStateProvider } from "../../src";
 import type { ViewerState } from "../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { getDefaultViewerChannelSettings } from "../../src/aics-image-viewer/shared/constants";
+import FirebaseRequest from "../../src/aics-image-viewer/shared/utils/firebase";
 import type { AppDataProps } from "../types";
 import { encodeImageUrlProp, parseViewerUrlParams } from "../utils/url_utils";
 import { FlexRowAlignCenter } from "./LandingPage/utils";
@@ -23,11 +24,15 @@ const DEFAULT_APP_PROPS: AppDataProps = {
   viewerChannelSettings: getDefaultViewerChannelSettings(),
 };
 
+type AppWrapperProps = {
+  firebaseDb: FirebaseRequest;
+};
+
 /**
  * Wrapper around the main ImageViewer component. Handles the collection of parameters from the
  * URL and location state (from routing) to pass to the viewer.
  */
-export default function AppWrapper(): ReactElement {
+export default function AppWrapper(props: AppWrapperProps): ReactElement {
   const location = useLocation();
   const navigation = useNavigate();
 
@@ -41,7 +46,7 @@ export default function AppWrapper(): ReactElement {
   useEffect(() => {
     // On load, fetch parameters from the URL and location state, then merge.
     const locationArgs = location.state as AppDataProps;
-    parseViewerUrlParams(searchParams).then(
+    parseViewerUrlParams(searchParams, props.firebaseDb).then(
       ({ args: urlArgs, viewerSettings: urlViewerSettings }) => {
         setViewerSettings({ ...urlViewerSettings, ...locationArgs?.viewerSettings });
         setViewerProps({ ...DEFAULT_APP_PROPS, ...urlArgs, ...locationArgs });

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router";
 import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 
+import FirebaseRequest from "../../../src/aics-image-viewer/shared/utils/firebase";
 import { BannerVideo } from "../../assets/videos";
 import type { AppDataProps, DatasetEntry, ProjectEntry } from "../../types";
 import { encodeImageUrlProp, parseViewerUrlParams } from "../../utils/url_utils";
@@ -236,7 +237,11 @@ const CookieSettingsButton = styled(Button)`
   }
 `;
 
-export default function LandingPage(): ReactElement {
+type LandingPageProps = {
+  firebaseDb: FirebaseRequest;
+};
+
+export default function LandingPage(props: LandingPageProps): ReactElement {
   // Rendering
   const navigation = useNavigate();
   const [searchParams] = useSearchParams();
@@ -245,7 +250,7 @@ export default function LandingPage(): ReactElement {
     // Check if the URL used to open the landing page has arguments;
     // if so, assume that this is an old URL intended to go to the viewer.
     // Navigate to the viewer while preserving URL arguments.
-    parseViewerUrlParams(searchParams).then(({ args }) => {
+    parseViewerUrlParams(searchParams, props.firebaseDb).then(({ args }) => {
       if (Object.keys(args).length > 0) {
         console.log("Detected URL parameters. Redirecting from landing page to viewer.");
         navigation("viewer" + "?" + searchParams.toString(), {
@@ -254,7 +259,7 @@ export default function LandingPage(): ReactElement {
         });
       }
     });
-  }, [navigation, searchParams]);
+  }, [navigation, searchParams, props.firebaseDb]);
 
   const onClickLoad = (appProps: AppDataProps, hideTitle?: boolean): void => {
     // TODO: Make URL search params from the appProps and append it to the viewer URL so the URL can be shared directly.

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -1,7 +1,6 @@
 import { CameraState, ControlPoint } from "@aics/vole-core";
 import { isEqual } from "lodash";
 
-import FirebaseRequest, { type DatasetMetaData } from "../../public/firebase";
 import type { AppProps, MultisceneUrls } from "../../src/aics-image-viewer/components/App/types";
 import type {
   ChannelState,
@@ -16,6 +15,7 @@ import {
 import { ImageType, RenderMode, ViewMode } from "../../src/aics-image-viewer/shared/enums";
 import type { ManifestJson, MetadataRecord, PerAxis } from "../../src/aics-image-viewer/shared/types";
 import { ColorArray } from "../../src/aics-image-viewer/shared/utils/colorRepresentations";
+import FirebaseRequest, { DatasetMetaData } from "../../src/aics-image-viewer/shared/utils/firebase";
 import type {
   ViewerChannelSetting,
   ViewerChannelSettings,
@@ -930,8 +930,7 @@ function parseChannelSettings(params: ChannelParams): ViewerChannelSettings | un
 }
 
 //// FULL URL PARSING //////////////////////
-async function loadDataset(dataset: string, id: string): Promise<Partial<AppProps>> {
-  const db = new FirebaseRequest();
+async function loadDataset(db: FirebaseRequest, dataset: string, id: string): Promise<Partial<AppProps>> {
   const args: Partial<AppProps> = {};
 
   const datasets = await db.getAvailableDatasets();
@@ -1022,7 +1021,10 @@ export async function loadFromManifest(
  * Parses a set of URL search parameters into a set of args/props for the viewer.
  * @param urlSearchParams
  */
-export async function parseViewerUrlParams(urlSearchParams: URLSearchParams): Promise<{
+export async function parseViewerUrlParams(
+  urlSearchParams: URLSearchParams,
+  db?: FirebaseRequest
+): Promise<{
   args: Partial<AppProps>;
   viewerSettings: Partial<ViewerState>;
 }> {
@@ -1088,9 +1090,9 @@ export async function parseViewerUrlParams(urlSearchParams: URLSearchParams): Pr
         ],
       };
     }
-  } else if (params.dataset && params.id) {
+  } else if (params.dataset && params.id && db) {
     // ?dataset=aics_hipsc_v2020.1&id=232265
-    const datasetArgs = await loadDataset(params.dataset, params.id);
+    const datasetArgs = await loadDataset(db, params.dataset, params.id);
     args = { ...args, ...datasetArgs };
   }
 


### PR DESCRIPTION
Problem
=======
I was working on https://github.com/allen-cell-animated/cell-feature-explorer/issues/237, which requires that we export the url parsing logic (`parseViewerUrlParams()` in `url_utils`). However, I was running into a compilation bug if I just moved `url_utils` directly.

It turns out that this is because it was importing the firebase configuration from `public`, which caused Typescript to compile `public` as a separate module. This change removes `url_utils`'s dependency on `public` and moves the firebase database initialization to `public/index.tsx`.

Solution
========
What I/we did to solve this problem

with @pairperson1

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update
* This change requires updated or new tests

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
